### PR TITLE
Propagate proxy invocation exception as is

### DIFF
--- a/mongock-core/src/main/java/com/github/cloudyrock/mongock/ProxyMethodInterceptor.java
+++ b/mongock-core/src/main/java/com/github/cloudyrock/mongock/ProxyMethodInterceptor.java
@@ -45,12 +45,18 @@ class ProxyMethodInterceptor implements MethodInterceptor {
     }
   }
 
-  private Object invokeMethod(Method method, Object[] objects) throws IllegalAccessException, InvocationTargetException {
-    final Object invocation = method.invoke(original, objects);
+  private Object invokeMethod(Method method, Object[] objects) throws Throwable {
+    Object invocation;
+    try {
+      invocation = method.invoke(original, objects);
+    } catch (InvocationTargetException e) {
+      throw e.getCause();
+    }
     if (proxyCreatorMethods.contains(method.getName())) {
       return proxyFactory.createProxyFromOriginal(invocation, method.getReturnType());
     } else {
       return invocation;
     }
   }
+
 }

--- a/mongock-core/src/test/java/com/github/cloudyrock/mongock/DummyClass.java
+++ b/mongock-core/src/test/java/com/github/cloudyrock/mongock/DummyClass.java
@@ -11,4 +11,11 @@ public class DummyClass {
     return value;
   }
 
+  public void throwException() throws DummyException {
+    throw new DummyException();
+  }
+
+  public static class DummyException extends Exception {
+  }
+
 }

--- a/mongock-core/src/test/java/com/github/cloudyrock/mongock/ProxyMethodInterceptorTest.java
+++ b/mongock-core/src/test/java/com/github/cloudyrock/mongock/ProxyMethodInterceptorTest.java
@@ -89,4 +89,25 @@ public class ProxyMethodInterceptorTest {
     assertEquals("ProxiedObject", result);
   }
 
+  @Test(expected = DummyClass.DummyException.class)
+  public void shouldPropagateExceptionAsIs() throws Throwable {
+    final DummyClass dummyInstance = new DummyClass("value1");
+
+    ProxyFactory proxyFactory = mock(ProxyFactory.class);
+    ProxyMethodInterceptor interceptor = new ProxyMethodInterceptor(
+        dummyInstance,
+        proxyFactory,
+        lockCheckerInterceptorMock,
+        Collections.singleton("throwException"),
+        Collections.singleton("throwException")
+    );
+
+    interceptor.intercept(
+        dummyInstance,
+        DummyClass.class.getMethod("throwException"),
+        new Object[0],
+        null
+    );
+  }
+
 }


### PR DESCRIPTION
## Improve project for library's clients code 

**MongoDriver** can throw some `Unchecked` exception.

But because this methods are called across proxy,
Library replaces this exceptions with `InvocationTargetException`.
So, clients' code can not catch source exception from **MongoDriver**.

This fix extracts exception as `throwable` source.