### PR TITLE
Replace Reflections library with Guava 28

### DIFF
--- a/mongock-core/pom.xml
+++ b/mongock-core/pom.xml
@@ -20,9 +20,9 @@
       <version>3.5.0</version><!-- Make sure that decorators are adapted to new version(see file dependency_upgrade_considerations -->
     </dependency>
     <dependency>
-      <groupId>org.reflections</groupId>
-      <artifactId>reflections</artifactId>
-      <version>0.9.9</version>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>28.0-jre</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Since Reflections contains a security vulnerability due to its dependency on Guava 14 I replaced it. Using Guava might be a controversial choice but I think implementing classpath scanning oneself isn't so good either. Also Guava receives updates more often than Reflections. 