### PR TITLE
Avoid `NullPointerException` in `Mongock.close`.

### DIFF
--- a/mongock-core/src/main/java/com/github/cloudyrock/mongock/Mongock.java
+++ b/mongock-core/src/main/java/com/github/cloudyrock/mongock/Mongock.java
@@ -115,8 +115,9 @@ public class Mongock implements Closeable {
    * The `mongoClientCloseable` may be null when using `mongoTemplate` instead of a `mongoClient`.
    */
   public void close() throws IOException {
-    if (mongoClientCloseable != null)
+    if (mongoClientCloseable != null) {
       mongoClientCloseable.close();
+    }
   }
 
   private void executeMigration() {

--- a/mongock-core/src/main/java/com/github/cloudyrock/mongock/Mongock.java
+++ b/mongock-core/src/main/java/com/github/cloudyrock/mongock/Mongock.java
@@ -112,9 +112,11 @@ public class Mongock implements Closeable {
   /**
    * Closes the Mongo instance used by Mongock.
    * This will close either the connection Mongock was initiated with or that which was internally created.
+   * The `mongoClientCloseable` may be null when using `mongoTemplate` instead of a `mongoClient`.
    */
   public void close() throws IOException {
-    mongoClientCloseable.close();
+    if (mongoClientCloseable != null)
+      mongoClientCloseable.close();
   }
 
   private void executeMigration() {


### PR DESCRIPTION
When using Mongock with a `MongoTemplate` instance instead of `MongoClient`
instance, the `mongoClientCloseable` field would be `null`. This leads to
throwing a NullPointerException in the close method when the bean is being
destroyed.

If this is not clear, let me know and I'll try to articulate it better with more details.

Thank you for your work.