### PR TITLE
updated lock strategy

### DIFF
--- a/mongodb-springdata-v2-driver/src/main/java/com/github/cloudyrock/mongock/driver/mongodb/springdata/v2/config/SpringDataMongoV2Context.java
+++ b/mongodb-springdata-v2-driver/src/main/java/com/github/cloudyrock/mongock/driver/mongodb/springdata/v2/config/SpringDataMongoV2Context.java
@@ -32,11 +32,11 @@ public class SpringDataMongoV2Context {
                                               MongockConfiguration config,
                                               MongoDBConfiguration mongoDbConfig,
                                               Optional<MongoTransactionManager> txManagerOpt) {
-    SpringDataMongoV2Driver driver = SpringDataMongoV2Driver.withLockSetting(
+    SpringDataMongoV2Driver driver = SpringDataMongoV2Driver.withLockStrategy(
         mongoTemplate,
-        config.getLockAcquiredForMinutes(),
-        config.getMaxWaitingForLockMinutes(),
-        config.getMaxTries());
+        config.getLockAcquiredForMillis(),
+        config.getLockQuitTryingAfterMillis(),
+        config.getLockTryFrequencyMillis());
     setGenericDriverConfig(config, txManagerOpt, driver);
     setMongoDBConfig(mongoDbConfig, driver);
     return driver;

--- a/mongodb-springdata-v3-driver/src/main/java/com/github/cloudyrock/mongock/driver/mongodb/springdata/v3/config/SpringDataMongoV3Context.java
+++ b/mongodb-springdata-v3-driver/src/main/java/com/github/cloudyrock/mongock/driver/mongodb/springdata/v3/config/SpringDataMongoV3Context.java
@@ -32,11 +32,11 @@ public class SpringDataMongoV3Context {
                                               MongockConfiguration config,
                                               MongoDBConfiguration mongoDbConfig,
                                               Optional<MongoTransactionManager> txManagerOpt) {
-    SpringDataMongoV3Driver driver = SpringDataMongoV3Driver.withLockSetting(
+    SpringDataMongoV3Driver driver = SpringDataMongoV3Driver.withLockStrategy(
         mongoTemplate,
-        config.getLockAcquiredForMinutes(),
-        config.getMaxWaitingForLockMinutes(),
-        config.getMaxTries());
+        config.getLockAcquiredForMillis(),
+        config.getLockQuitTryingAfterMillis(),
+        config.getLockTryFrequencyMillis());
     setGenericDriverConfig(config, txManagerOpt, driver);
     setMongoDBConfig(mongoDbConfig, driver);
     return driver;

--- a/mongodb-sync-v4-driver/src/main/java/com/github/cloudyrock/mongock/driver/mongodb/sync/v4/driver/MongoSync4Driver.java
+++ b/mongodb-sync-v4-driver/src/main/java/com/github/cloudyrock/mongock/driver/mongodb/sync/v4/driver/MongoSync4Driver.java
@@ -6,6 +6,7 @@ import com.github.cloudyrock.mongock.driver.api.entry.ChangeEntryService;
 import com.github.cloudyrock.mongock.driver.mongodb.sync.v4.changelogs.runalways.MongockSync4LegacyMigrationChangeRunAlwaysLog;
 import com.github.cloudyrock.mongock.driver.mongodb.sync.v4.changelogs.runonce.MongockSync4LegacyMigrationChangeLog;
 import com.github.cloudyrock.mongock.driver.mongodb.sync.v4.repository.MongoSync4ChangeEntryRepository;
+import com.github.cloudyrock.mongock.utils.TimeService;
 import com.github.cloudyrock.mongock.utils.annotation.NotThreadSafe;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoDatabase;
@@ -17,32 +18,53 @@ public class MongoSync4Driver extends MongoSync4DriverBase<ChangeEntry> {
 
   protected MongoSync4ChangeEntryRepository<ChangeEntry> changeEntryRepository;
 
+  private static final TimeService TIME_SERVICE = new TimeService();
+
+
+  //TODO CENTRALIZE DEFAULT PROPERTIES
   public static MongoSync4Driver withDefaultLock(MongoClient mongoClient, String databaseName) {
-    return new MongoSync4Driver(mongoClient, databaseName, 3L, 4L, 3);
+    return MongoSync4Driver.withLockStrategy(mongoClient, databaseName, 60 * 1000L, 3 * 60 * 1000L, 1000L);
   }
 
+  public static MongoSync4Driver withLockStrategy(MongoClient mongoClient,
+                                                 String databaseName,
+                                                 long lockAcquiredForMillis,
+                                                 long lockQuitTryingAfterMillis,
+                                                 long lockTryFrequencyMillis) {
+    return new MongoSync4Driver(mongoClient, databaseName, lockAcquiredForMillis, lockQuitTryingAfterMillis, lockTryFrequencyMillis);
+  }
+
+
+  /**
+   * @Deprecated
+   * Use withLockStrategy instead
+   */
+  @Deprecated
   public static MongoSync4Driver withLockSetting(MongoClient mongoClient,
                                                  String databaseName,
                                                  long lockAcquiredForMinutes,
                                                  long maxWaitingForLockMinutes,
                                                  int maxTries) {
-    return new MongoSync4Driver(mongoClient, databaseName, lockAcquiredForMinutes, maxWaitingForLockMinutes, maxTries);
+    long lockAcquiredForMillis = TIME_SERVICE.minutesToMillis(lockAcquiredForMinutes);
+    long lockQuitTryingAfterMillis = TIME_SERVICE.minutesToMillis(maxWaitingForLockMinutes * maxTries);
+    long tryFrequency = 1000L;// 1 second
+    return MongoSync4Driver.withLockStrategy(mongoClient, databaseName, lockAcquiredForMillis, lockQuitTryingAfterMillis, tryFrequency);
   }
 
   // For children classes like SpringData drivers
   protected MongoSync4Driver(MongoDatabase mongoDatabase,
-                             long lockAcquiredForMinutes,
-                             long maxWaitingForLockMinutes,
-                             int maxTries) {
-    super(mongoDatabase, lockAcquiredForMinutes, maxWaitingForLockMinutes, maxTries);
+                             long lockAcquiredForMillis,
+                             long lockQuitTryingAfterMillis,
+                             long lockTryFrequencyMillis) {
+    super(mongoDatabase, lockAcquiredForMillis, lockQuitTryingAfterMillis, lockTryFrequencyMillis);
   }
 
   protected MongoSync4Driver(MongoClient mongoClient,
                              String databaseName,
-                             long lockAcquiredForMinutes,
-                             long maxWaitingForLockMinutes,
-                             int maxTries) {
-    super(mongoClient, databaseName, lockAcquiredForMinutes, maxWaitingForLockMinutes, maxTries);
+                             long lockAcquiredForMillis,
+                             long lockQuitTryingAfterMillis,
+                             long lockTryFrequencyMillis) {
+    super(mongoClient, databaseName, lockAcquiredForMillis, lockQuitTryingAfterMillis, lockTryFrequencyMillis);
   }
 
   @Override

--- a/mongodb-sync-v4-driver/src/main/java/com/github/cloudyrock/mongock/driver/mongodb/sync/v4/driver/MongoSync4DriverBase.java
+++ b/mongodb-sync-v4-driver/src/main/java/com/github/cloudyrock/mongock/driver/mongodb/sync/v4/driver/MongoSync4DriverBase.java
@@ -56,19 +56,19 @@ public abstract class MongoSync4DriverBase<CHANGE_ENTRY extends ChangeEntry>
 
   protected MongoSync4DriverBase(MongoClient mongoClient,
                                  String databaseName,
-                                 long lockAcquiredForMinutes,
-                                 long maxWaitingForLockMinutes,
-                                 int maxTries) {
-    this(mongoClient.getDatabase(databaseName), lockAcquiredForMinutes, maxWaitingForLockMinutes, maxTries);
+                                 long lockAcquiredForMillis,
+                                 long lockQuitTryingAfterMillis,
+                                 long lockTryFrequencyMillis) {
+    this(mongoClient.getDatabase(databaseName), lockAcquiredForMillis, lockQuitTryingAfterMillis, lockTryFrequencyMillis);
     this.mongoClient = mongoClient;
     this.transactionStrategy = TransactionStrategy.MIGRATION;
   }
 
   protected MongoSync4DriverBase(MongoDatabase mongoDatabase,
-                                 long lockAcquiredForMinutes,
-                                 long maxWaitingForLockMinutes,
-                                 int maxTries) {
-    super(lockAcquiredForMinutes, maxWaitingForLockMinutes, maxTries);
+                                 long lockAcquiredForMillis,
+                                 long lockQuitTryingAfterMillis,
+                                 long lockTryFrequencyMillis) {
+    super(lockAcquiredForMillis, lockQuitTryingAfterMillis, lockTryFrequencyMillis);
     this.mongoDatabase = mongoDatabase;
     this.transactionStrategy = TransactionStrategy.NONE;
   }

--- a/mongodb-v3-driver/src/main/java/com/github/cloudyrock/mongock/driver/mongodb/v3/driver/MongoCore3DriverBase.java
+++ b/mongodb-v3-driver/src/main/java/com/github/cloudyrock/mongock/driver/mongodb/v3/driver/MongoCore3DriverBase.java
@@ -54,21 +54,21 @@ public abstract class MongoCore3DriverBase<CHANGE_ENTRY extends ChangeEntry>
   private ReadConcern readConcern;
   private ReadPreference readPreference;
 
-  MongoCore3DriverBase(MongoClient mongoClient,
-                       String databaseName,
-                       long lockAcquiredForMinutes,
-                       long maxWaitingForLockMinutes,
-                       int maxTries) {
-    this(mongoClient.getDatabase(databaseName), lockAcquiredForMinutes, maxWaitingForLockMinutes, maxTries);
+  protected MongoCore3DriverBase(MongoClient mongoClient,
+                                 String databaseName,
+                                 long lockAcquiredForMillis,
+                                 long lockQuitTryingAfterMillis,
+                                 long lockTryFrequencyMillis) {
+    this(mongoClient.getDatabase(databaseName), lockAcquiredForMillis, lockQuitTryingAfterMillis, lockTryFrequencyMillis);
     this.mongoClient = mongoClient;
     this.transactionStrategy = TransactionStrategy.MIGRATION;
   }
 
-  MongoCore3DriverBase(MongoDatabase mongoDatabase,
-                       long lockAcquiredForMinutes,
-                       long maxWaitingForLockMinutes,
-                       int maxTries) {
-    super(lockAcquiredForMinutes, maxWaitingForLockMinutes, maxTries);
+  protected MongoCore3DriverBase(MongoDatabase mongoDatabase,
+                                 long lockAcquiredForMillis,
+                                 long lockQuitTryingAfterMillis,
+                                 long lockTryFrequencyMillis) {
+    super(lockAcquiredForMillis, lockQuitTryingAfterMillis, lockTryFrequencyMillis);
     this.mongoDatabase = mongoDatabase;
     this.transactionStrategy = TransactionStrategy.NONE;
   }


### PR DESCRIPTION
## Title of the work done
New lock acquisition strategy


A clear and concise description of what the change is.

## Additional context

Add any other context about the problem here.

## Modules affected
- [ ] mongock-bom
- [X] mongodb-sync-v4-driver
- [X] mongodb-springdata-v3-driver
- [X] mongodb-v3-driver
- [X] mongodb-springdata-v2-driver
- [ ] mongodb-driver-test-template  

## Checklist before PR
- [ ] Branch name follows strategy (ISSUE|FEATURE|REFACTOR|DOC|TEST)[-issue_number][/description_underscored]. 

      Ex: ISSUE-294/fix_read_concern_driver_v3
- [ ] If depends on a new change in the mongock-core project, version updated and snapshot removed
- [X] Unit tests provided
- [X] Integration tests provided in [separated project](https://github.com/cloudyrock/mongock-integration-tests)
- [ ] Github build passing
- [X] Codacy analysis not adding new issues
- [ ] Documentation updated
- [ ] [Example projects](https://github.com/cloudyrock/mongock-examples) updated

