### PR TITLE
runner bean not injected when cli profile

### DIFF
--- a/drivers/mongock-driver-mongodb/mongodb-springdata-v3-driver/pom.xml
+++ b/drivers/mongock-driver-mongodb/mongodb-springdata-v3-driver/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>mongodb-driver-sync</artifactId>
-      <version>4.2.3</version>
+      <version>${spring-data-3.mongodb.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/drivers/mongock-driver-mongodb/pom.xml
+++ b/drivers/mongock-driver-mongodb/pom.xml
@@ -30,7 +30,12 @@
 
     <spring-boot.version>[2.0.0, 3.0.0)</spring-boot.version>
     <spring-data-3.version>3.2.5</spring-data-3.version>
+    <spring-data-3.mongodb.version>4.2.3</spring-data-3.mongodb.version>
+
+
     <spring-data-2.version>2.2.13.RELEASE</spring-data-2.version>
+    <spring-data-2.mongodb.version>3.11.2</spring-data-2.mongodb.version>
+
     <mongodb-sync-4.version>[4.0.0, 5.0.0)</mongodb-sync-4.version>
     <mongodb-driver-3.version>[3.0.0, 4.0.0)</mongodb-driver-3.version>
 

--- a/mongock-core/mongock-runner/spring/springboot/mongock-springboot-base/pom.xml
+++ b/mongock-core/mongock-runner/spring/springboot/mongock-springboot-base/pom.xml
@@ -42,6 +42,10 @@
       <artifactId>mongock-spring-base</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.mongock</groupId>
+      <artifactId>mongock-utils</artifactId>
+    </dependency>
 
     <!-- SPRING BOOT -->
 

--- a/mongock-core/mongock-runner/spring/springboot/mongock-springboot-base/src/main/java/io/mongock/runner/springboot/base/config/MongockContextBase.java
+++ b/mongock-core/mongock-runner/spring/springboot/mongock-springboot-base/src/main/java/io/mongock/runner/springboot/base/config/MongockContextBase.java
@@ -6,25 +6,29 @@ import io.mongock.driver.api.entry.ChangeEntry;
 import io.mongock.runner.springboot.base.MongockApplicationRunner;
 import io.mongock.runner.springboot.base.MongockInitializingBeanRunner;
 import io.mongock.runner.springboot.base.builder.SpringApplicationBean;
+import io.mongock.utils.Constants;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
-
+import org.springframework.context.annotation.Profile;
 
 public abstract class MongockContextBase<CHANGE_ENTRY extends ChangeEntry, CONFIG extends MongockConfiguration> {
 
   @Bean
+  @Profile("!" + Constants.CLI_PROFILE)
   @ConditionalOnExpression("'${mongock.runner-type:ApplicationRunner}'.toLowerCase().equals('applicationrunner')")
   public MongockApplicationRunner applicationRunner(ConnectionDriver<CHANGE_ENTRY> connectionDriver,
                                                     CONFIG springConfiguration,
                                                     ApplicationContext springContext,
                                                     ApplicationEventPublisher applicationEventPublisher) {
+
     return getBuilder(connectionDriver, springConfiguration, springContext, applicationEventPublisher)
         .buildApplicationRunner();
   }
 
   @Bean
+  @Profile("!" + Constants.CLI_PROFILE)
   @ConditionalOnExpression("'${mongock.runner-type:null}'.toLowerCase().equals('initializingbean')")
   public MongockInitializingBeanRunner initializingBeanRunner(ConnectionDriver<CHANGE_ENTRY> connectionDriver,
                                                               CONFIG springConfiguration,


### PR DESCRIPTION
## Title of the work done
Brief title of the PR


## Description

> [Issue <ISSUE_NUMBE>](https://github.com/cloudyrock/mongock/issues/<ISSUE_NUMBE>)

A clear and concise description of what the change is.

## Additional context

Add any other context about the problem here.

## Modules affected
- [ ] mongock-driver-mongodb-bom
- [ ] mongodb-sync-v4-driver
- [ ] mongodb-springdata-v3-driver
- [ ] mongodb-v3-driver
- [ ] mongodb-springdata-v2-driver
- [ ] mongodb-driver-test-template  

## Checklist before PR
- [ ] Branch name follows strategy (ISSUE|FEATURE|REFACTOR|DOC|TEST)[-issue_number][/description_underscored]. 

      Ex: ISSUE-294/fix_read_concern_driver_v3
- [ ] If depends on a new change in the mongock-core project, version updated and snapshot removed
- [ ] Unit tests provided
- [ ] Integration tests provided in [separated project](https://github.com/cloudyrock/mongock-integration-tests)
- [ ] Github build passing
- [ ] Codacy analysis not adding new issues
- [ ] Documentation updated
- [ ] [Example projects](https://github.com/cloudyrock/mongock-examples) updated

