### PR TITLE
Remove useless @Configuration on MongockSpringConfiguration and causes issues with spring-native

### DIFF
--- a/mongock-core/mongock-runner/spring/springboot/mongock-springboot/src/main/java/io/mongock/runner/springboot/config/MongockSpringConfiguration.java
+++ b/mongock-core/mongock-runner/spring/springboot/mongock-springboot/src/main/java/io/mongock/runner/springboot/config/MongockSpringConfiguration.java
@@ -4,9 +4,7 @@ import io.mongock.api.config.MongockConfiguration;
 import io.mongock.runner.springboot.base.config.MongockSpringConfigurationBase;
 import io.mongock.runner.springboot.base.config.SpringRunnerType;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
 @ConfigurationProperties("mongock")
 public class MongockSpringConfiguration extends MongockConfiguration implements MongockSpringConfigurationBase {
 


### PR DESCRIPTION
## Remove useless @Configuration on MongockSpringConfiguration and causes issues with spring-native

## Description

When trying to use mongock in a spring-native application, the _useless_ `@Configuration` annotation on the `@ConfigurationProperties` class confuses the aot engine and prevent to start the app.

## Checklist before PR
- [x] Branch name follows strategy (ISSUE|FEATURE|REFACTOR|DOC|TEST)[-issue_number][/description_underscored]. 

      Ex: ISSUE-294/fix_read_concern_driver_v3
- [x] If depends on a new change in the mongock-core project, version updated and snapshot removed
- [x] Unit tests provided
- [x] Integration tests provided in [separated project](https://github.com/cloudyrock/mongock-integration-tests)
- [x] Github build passing
- [x] Codacy analysis not adding new issues
- [x] Documentation updated
- [x] [Example projects](https://github.com/cloudyrock/mongock-examples) updated

