### PR TITLE
Fix javadoc misleading deprecation

### DIFF
--- a/mongock-core/mongock-runner/mongock-runner-core/src/main/java/io/mongock/runner/core/builder/roles/ChangeLogScanner.java
+++ b/mongock-core/mongock-runner/mongock-runner-core/src/main/java/io/mongock/runner/core/builder/roles/ChangeLogScanner.java
@@ -98,7 +98,7 @@ public interface ChangeLogScanner<SELF extends ChangeLogScanner<SELF, CONFIG>, C
   }
 
   /**
-   * Deprecated. Use addChangeLogsScanPackage instead
+   * Deprecated. Use addMigrationScanPackage instead
    */
   @Deprecated
   default SELF addChangeLogsScanPackage(String migrationScanPackage) {
@@ -106,7 +106,7 @@ public interface ChangeLogScanner<SELF extends ChangeLogScanner<SELF, CONFIG>, C
   }
 
   /**
-   * Deprecated. Use addChangeLogClasses instead
+   * Deprecated. Use addMigrationClasses instead
    */
   @Deprecated
   default SELF addChangeLogClasses(List<Class<?>> classes) {
@@ -114,7 +114,7 @@ public interface ChangeLogScanner<SELF extends ChangeLogScanner<SELF, CONFIG>, C
   }
 
   /**
-   * Deprecated. Use addChangeLogClass instead
+   * Deprecated. Use addMigrationClass instead
    */
   @Deprecated
   default SELF addChangeLogClass(Class<?> clazz) {


### PR DESCRIPTION
## Issue reference
none

## Documentation PR reference
not needed

## Description and context
There were an issue in the deprecated javadoc of the ChangeLogScanner

## Benefits
Fix javadoc

## Possible Drawbacks
none

## Checklist 
- [ ] Unit tests provided
- [ ] Integration tests provided 
- [x] Documentation updated in [documentation project](https://github.com/mongock/mongock-docs)
- [ ] Updated example in [example projects](https://github.com/mongock/mongock-examples)

Cheers ;)

