### PR TITLE
Sleuth support

### DIFF
--- a/drivers/mongock-driver-mongodb/integration-tests/pom.xml
+++ b/drivers/mongock-driver-mongodb/integration-tests/pom.xml
@@ -22,6 +22,8 @@
     <junit.version>4.13</junit.version>
     <junit.jupiter.version>5.6.2</junit.jupiter.version>
     <junit.vintage.version>5.6.2</junit.vintage.version>
+    <spring-cloud-sleuth.version>3.1.0</spring-cloud-sleuth.version>
+    <test-containers.version>1.16.2</test-containers.version>
   </properties>
 
 
@@ -43,6 +45,11 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
       <version>${spring-boot.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-sleuth</artifactId>
+      <version>${spring-cloud-sleuth.version}</version>
     </dependency>
 
     <dependency>
@@ -94,7 +101,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>mongodb</artifactId>
-      <version>1.15.0</version>
+      <version>${test-containers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -105,7 +112,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>1.14.2</version>
+      <version>${test-containers.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/drivers/mongock-driver-mongodb/integration-tests/src/test/java/io/mongock/integrationtests/spring5/springdata3/RuntimeTestUtil.java
+++ b/drivers/mongock-driver-mongodb/integration-tests/src/test/java/io/mongock/integrationtests/spring5/springdata3/RuntimeTestUtil.java
@@ -1,6 +1,7 @@
 package io.mongock.integrationtests.spring5.springdata3;
 
 import io.mongock.integrationtests.spring5.springdata3.util.MongoContainer;
+import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.context.ConfigurableApplicationContext;
 
 import java.util.HashMap;
@@ -10,73 +11,94 @@ import java.util.stream.Collectors;
 
 public abstract class RuntimeTestUtil {
 
-    public static final String DEFAULT_DATABASE_NAME = "mongocktest";
+  public static final String DEFAULT_DATABASE_NAME = "mongocktest";
 
 
-    public static MongoContainer startMongoDbContainer(String mongoDockerImage) {
-        MongoContainer mongoContiner =  MongoContainer.builder().mongoDockerImageName(mongoDockerImage).build();
-        mongoContiner.start();
+  public static MongoContainer startMongoDbContainer(String mongoDockerImage) {
+    MongoContainer mongoContiner = MongoContainer.builder().mongoDockerImageName(mongoDockerImage).build();
+    mongoContiner.start();
 
-        String replicaSetUrl = mongoContiner.getReplicaSetUrl();
-        return mongoContiner;
+    String replicaSetUrl = mongoContiner.getReplicaSetUrl();
+    return mongoContiner;
+  }
+
+  public static ConfigurableApplicationContext startSpringAppWithMongoDbVersionAndDefaultPackage(String mongoVersion) {
+    return startSpringAppWithMongoDbVersionAndDefaultPackage(
+        mongoVersion,
+        false
+    );
+  }
+
+  public static ConfigurableApplicationContext startSpringAppWithMongoDbVersionAndDefaultPackage(String mongoVersion, boolean sleuthEnabled) {
+    return startSpringAppWithMongoDbVersionAndPackage(
+        mongoVersion,
+        "io.mongock.integrationtests.spring5.springdata3.changelogs.client",
+        sleuthEnabled
+    );
+  }
+
+  public static ConfigurableApplicationContext startSpringAppWithMongoDbVersionAndNoPackage(String mongoDBVersion, boolean sleuthEnabled) {
+    Map<String, String> parameters = new HashMap<>();
+    parameters.put("spring.sleuth.enabled", String.valueOf(sleuthEnabled));
+    parameters.put("mongock.changeLogsScanPackage", "");
+    parameters.put("mongock.transactionable", "false");
+    return startSpringAppWithMongoDbVersionAndParameters(mongoDBVersion, parameters);
+  }
+
+  public static ConfigurableApplicationContext startSpringAppWithMongoDbVersionAndNoPackage(String mongoDBVersion) {
+    return startSpringAppWithMongoDbVersionAndNoPackage(mongoDBVersion, false);
+  }
+
+  public static ConfigurableApplicationContext startSpringAppWithMongoDbVersionAndPackage(String mongoDBVersion, String packagePath) {
+    return startSpringAppWithMongoDbVersionAndPackage(mongoDBVersion, packagePath, false);
+  }
+
+  public static ConfigurableApplicationContext startSpringAppWithMongoDbVersionAndPackage(String mongoDBVersion, String packagePath, boolean sleuthEnabled) {
+    Map<String, String> parameters = new HashMap<>();
+    parameters.put("spring.sleuth.enabled", String.valueOf(sleuthEnabled));
+    parameters.put("mongock.changeLogsScanPackage", packagePath);
+    return startSpringAppWithMongoDbVersionAndParameters(mongoDBVersion, parameters);
+  }
+
+  public static ConfigurableApplicationContext startSpringAppWithTransactionDisabledMongoDbVersionAndPackage(String mongoDBVersion, String packagePath, boolean sleuthEnabled) {
+    Map<String, String> parameters = new HashMap<>();
+    parameters.put("spring.sleuth.enabled", String.valueOf(sleuthEnabled));
+    parameters.put("mongock.changeLogsScanPackage", packagePath);
+    parameters.put("mongock.transactionable", "false");
+    return startSpringAppWithMongoDbVersionAndParameters(mongoDBVersion, parameters);
+  }
+
+  public static ConfigurableApplicationContext startSpringAppWithTransactionDisabledMongoDbVersionAndPackage(String mongoDBVersion, String packagePath) {
+    return startSpringAppWithTransactionDisabledMongoDbVersionAndPackage(mongoDBVersion, packagePath, false);
+  }
+
+  public static ConfigurableApplicationContext startSpringAppWithMongoDbVersionAndParameters(String mongoDBVersion, Map<String, String> parameters) {
+    return startSpringAppWithParameters(startMongoDbContainer(mongoDBVersion), parameters);
+  }
+
+
+  public static ConfigurableApplicationContext startSpringAppWithParameters(MongoContainer container, Map<String, String> parameters) {
+    String[] parametersArray = getParametersArray(container, parameters);
+    return Mongock4Spring5SpringData3App.getSpringAppBuilder().properties(parametersArray).run();
+  }
+
+  private static String[] getParametersArray(MongoContainer container, Map<String, String> parameters) {
+    String replicaSetUrl = container.getReplicaSetUrl();
+    List<String> parametersList = parameters.entrySet()
+        .stream()
+        .map(entry -> String.format("%s=%s", entry.getKey(), entry.getValue()))
+        .collect(Collectors.toList());
+    if (!parameters.containsKey("server.port")) {
+      parametersList.add("server.port=0");
     }
-
-    public static ConfigurableApplicationContext startSpringAppWithMongoDbVersionAndDefaultPackage(String mongoVersion) {
-        return startSpringAppWithMongoDbVersionAndPackage(
-                mongoVersion,
-                "io.mongock.integrationtests.spring5.springdata3.changelogs.client"
-        );
+    if (!parameters.containsKey("mongock.transactionable")) {
+      parametersList.add("mongock.transactionable=" + container.isTransactionable());
     }
-
-    public static ConfigurableApplicationContext startSpringAppWithMongoDbVersionAndNoPackage(String mongoDBVersion) {
-
-        Map<String, String> parameters = new HashMap<>();
-        parameters.put("mongock.changeLogsScanPackage", "");
-        parameters.put("mongock.transactionable", "false");
-        return startSpringAppWithMongoDbVersionAndParameters(mongoDBVersion, parameters);
-    }
-
-    public static ConfigurableApplicationContext startSpringAppWithMongoDbVersionAndPackage(String mongoDBVersion, String packagePath) {
-        Map<String, String> parameters = new HashMap<>();
-        parameters.put("mongock.changeLogsScanPackage", packagePath);
-        return startSpringAppWithMongoDbVersionAndParameters(mongoDBVersion, parameters);
-    }
-
-    public static ConfigurableApplicationContext startSpringAppWithTransactionDisabledMongoDbVersionAndPackage(String mongoDBVersion, String packagePath) {
-        Map<String, String> parameters = new HashMap<>();
-        parameters.put("mongock.changeLogsScanPackage", packagePath);
-        parameters.put("mongock.transactionable", "false");
-        return startSpringAppWithMongoDbVersionAndParameters(mongoDBVersion, parameters);
-    }
-
-
-    public static ConfigurableApplicationContext startSpringAppWithMongoDbVersionAndParameters(String mongoDBVersion, Map<String, String> parameters) {
-        return startSpringAppWithParameters(startMongoDbContainer(mongoDBVersion), parameters);
-    }
-
-
-    public static ConfigurableApplicationContext startSpringAppWithParameters(MongoContainer container, Map<String, String> parameters) {
-        String[] parametersArray = getParametersArray(container, parameters);
-        return Mongock4Spring5SpringData3App.getSpringAppBuilder().properties(parametersArray).run();
-    }
-
-    private static String[] getParametersArray(MongoContainer container, Map<String, String> parameters) {
-        String replicaSetUrl = container.getReplicaSetUrl();
-        List<String> parametersList = parameters.entrySet()
-                .stream()
-                .map(entry -> String.format("%s=%s", entry.getKey(), entry.getValue()))
-                .collect(Collectors.toList());
-        if(!parameters.containsKey("server.port")) {
-            parametersList.add("server.port=0");
-        }
-        if(!parameters.containsKey("mongock.transactionable")) {
-            parametersList.add("mongock.transactionable=" + container.isTransactionable());
-        }
-        parametersList.add("spring.data.mongodb.uri=" + replicaSetUrl);
-        parametersList.add("spring.data.mongodb.database=" + DEFAULT_DATABASE_NAME);
-        String[] parametersArray = new String[parametersList.size()];
-        return parametersList.toArray(parametersArray);
-    }
+    parametersList.add("spring.data.mongodb.uri=" + replicaSetUrl);
+    parametersList.add("spring.data.mongodb.database=" + DEFAULT_DATABASE_NAME);
+    String[] parametersArray = new String[parametersList.size()];
+    return parametersList.toArray(parametersArray);
+  }
 
 
 }

--- a/drivers/mongock-driver-mongodb/integration-tests/src/test/java/io/mongock/integrationtests/spring5/springdata3/SpringApplicationLegacyMigrationITest.java
+++ b/drivers/mongock-driver-mongodb/integration-tests/src/test/java/io/mongock/integrationtests/spring5/springdata3/SpringApplicationLegacyMigrationITest.java
@@ -10,6 +10,8 @@ import com.mongodb.client.MongoDatabase;
 import org.bson.Document;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -17,6 +19,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import static org.awaitility.Awaitility.await;
 
@@ -25,87 +28,96 @@ import static org.awaitility.Awaitility.await;
 @Testcontainers
 class SpringApplicationLegacyMigrationITest {
 
-    private ConfigurableApplicationContext ctx;
+  private ConfigurableApplicationContext ctx;
 
-    @AfterEach
-    void closingSpringApp() {
-        if (ctx != null) {
-            ctx.close();
-            await().atMost(1, TimeUnit.MINUTES)
-                    .pollInterval(1, TimeUnit.SECONDS)
-                    .until(() -> !ctx.isActive());
-        }
+  @AfterEach
+  void closingSpringApp() {
+    if (ctx != null) {
+      ctx.close();
+      await().atMost(1, TimeUnit.MINUTES)
+          .pollInterval(1, TimeUnit.SECONDS)
+          .until(() -> !ctx.isActive());
+    }
+  }
+
+  private void closeSpringApp() {
+    if (ctx != null) {
+      ctx.close();
+      await().atMost(1, TimeUnit.MINUTES)
+          .pollInterval(1, TimeUnit.SECONDS)
+          .until(() -> !ctx.isActive());
+    }
+  }
+
+  private static Stream<Arguments> provider() {
+    return Stream.of(
+        Arguments.of("mongo:4.2.6", false),
+        Arguments.of("mongo:4.2.6", true)
+    );
+  }
+
+
+  //TODO: test for legacyMigration
+  // - should run normal with no run always
+  // - should run normal with run always
+  // - should not be tracked twice if executed twice but not run always
+  // - should be tracked twice if executed twice and run always
+
+  @ParameterizedTest
+  @MethodSource("provider")
+  void shouldRunLegacyMigration_IfNotHasRunYet(String mongoDbVersion, boolean sleuthEnabled) {
+    MongoContainer mongoContainer = RuntimeTestUtil.startMongoDbContainer(mongoDbVersion);
+    String replicaSetUrl = mongoContainer.getReplicaSetUrl();
+    MongoDatabase database = MongoClients.create(replicaSetUrl).getDatabase(RuntimeTestUtil.DEFAULT_DATABASE_NAME);
+    LegacyMigrationUtils.setUpLegacyMigration(database.getCollection(LegacyMigrationUtils.LEGACY_CHANGELOG_COLLECTION_NAME));
+    try {
+      Map<String, String> parameters = new HashMap<>();
+      parameters.put("spring.sleuth.enabled", String.valueOf(sleuthEnabled));
+      parameters.put("mongock.changeLogsScanPackage", EmptyChangeLog.class.getPackage().getName());
+      parameters.put("mongock.legacy-migration.origin", LegacyMigrationUtils.LEGACY_CHANGELOG_COLLECTION_NAME);
+      ctx = RuntimeTestUtil.startSpringAppWithParameters(mongoContainer, parameters);
+    } catch (Exception ex) {
+      //ignore
     }
 
-    private void closeSpringApp() {
-        if (ctx != null) {
-            ctx.close();
-            await().atMost(1, TimeUnit.MINUTES)
-                    .pollInterval(1, TimeUnit.SECONDS)
-                    .until(() -> !ctx.isActive());
-        }
+    // then
+    LegacyMigrationUtils.checkLegacyMigration(database.getCollection(Constants.CHANGELOG_COLLECTION_NAME), false, 1);
+    closeSpringApp();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provider")
+  void shouldNotRunLegacyMigration_IfNotRunAlways_WhenItIsAlreadyExecuted(String mongoDbVersion, boolean sleuthEnabled) {
+    runLegacyMigrationWhenPreviouslyExecuted(mongoDbVersion, false, 1, sleuthEnabled);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provider")
+  void shouldRunLegacyMigration_IfRunAlways_WhenItIsAlreadyExecuted(String mongoDbVersion, boolean sleuthEnabled) {
+    runLegacyMigrationWhenPreviouslyExecuted(mongoDbVersion, true, 1, sleuthEnabled);
+  }
+
+  private void runLegacyMigrationWhenPreviouslyExecuted(String mongoDbVersion, boolean runAlways, int executions, boolean sleuthEnabled) {
+    MongoContainer mongoContainer = RuntimeTestUtil.startMongoDbContainer(mongoDbVersion);
+    String replicaSetUrl = mongoContainer.getReplicaSetUrl();
+    MongoDatabase database = MongoClients.create(replicaSetUrl).getDatabase(RuntimeTestUtil.DEFAULT_DATABASE_NAME);
+    MongoCollection<Document> currentChangeLogCollection = database.getCollection(Constants.CHANGELOG_COLLECTION_NAME);
+    LegacyMigrationUtils.setUpAlreadyMigratedLegacyMigrationChange(currentChangeLogCollection, runAlways);
+    LegacyMigrationUtils.setUpLegacyMigration(database.getCollection(LegacyMigrationUtils.LEGACY_CHANGELOG_COLLECTION_NAME));
+    try {
+      Map<String, String> parameters = new HashMap<>();
+      parameters.put("spring.sleuth.enabled", String.valueOf(sleuthEnabled));
+      parameters.put("mongock.changeLogsScanPackage", EmptyChangeLog.class.getPackage().getName());
+      parameters.put("mongock.legacy-migration.origin", LegacyMigrationUtils.LEGACY_CHANGELOG_COLLECTION_NAME);
+      parameters.put("mongock.legacy-migration.run-always", Boolean.toString(runAlways));
+      ctx = RuntimeTestUtil.startSpringAppWithParameters(mongoContainer, parameters);
+    } catch (Exception ex) {
+      //ignore
     }
 
-
-    //TODO: test for legacyMigration
-    // - should run normal with no run always
-    // - should run normal with run always
-    // - should not be tracked twice if executed twice but not run always
-    // - should be tracked twice if executed twice and run always
-
-    @ParameterizedTest
-    @ValueSource(strings = {"mongo:4.2.6"})
-    void shouldRunLegacyMigration_IfNotHasRunYet(String mongoDbVersion) {
-        MongoContainer mongoContainer = RuntimeTestUtil.startMongoDbContainer(mongoDbVersion);
-        String replicaSetUrl = mongoContainer.getReplicaSetUrl();
-        MongoDatabase database = MongoClients.create(replicaSetUrl).getDatabase(RuntimeTestUtil.DEFAULT_DATABASE_NAME);
-        LegacyMigrationUtils.setUpLegacyMigration(database.getCollection(LegacyMigrationUtils.LEGACY_CHANGELOG_COLLECTION_NAME));
-        try {
-            Map<String, String> parameters = new HashMap<>();
-            parameters.put("mongock.changeLogsScanPackage",  EmptyChangeLog.class.getPackage().getName());
-            parameters.put("mongock.legacy-migration.origin",  LegacyMigrationUtils.LEGACY_CHANGELOG_COLLECTION_NAME);
-            ctx = RuntimeTestUtil.startSpringAppWithParameters(mongoContainer, parameters);
-        } catch (Exception ex) {
-            //ignore
-        }
-
-        // then
-        LegacyMigrationUtils.checkLegacyMigration(database.getCollection(Constants.CHANGELOG_COLLECTION_NAME), false, 1);
-        closeSpringApp();
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"mongo:4.2.6"})
-    void shouldNotRunLegacyMigration_IfNotRunAlways_WhenItIsAlreadyExecuted(String mongoDbVersion) {
-        runLegacyMigrationWhenPreviouslyExecuted(mongoDbVersion, false, 1);
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"mongo:4.2.6"})
-    void shouldRunLegacyMigration_IfRunAlways_WhenItIsAlreadyExecuted(String mongoDbVersion) {
-        runLegacyMigrationWhenPreviouslyExecuted(mongoDbVersion, true, 1);
-    }
-
-    private void runLegacyMigrationWhenPreviouslyExecuted(String mongoDbVersion, boolean runAlways, int executions) {
-        MongoContainer mongoContainer = RuntimeTestUtil.startMongoDbContainer(mongoDbVersion);
-        String replicaSetUrl = mongoContainer.getReplicaSetUrl();
-        MongoDatabase database = MongoClients.create(replicaSetUrl).getDatabase(RuntimeTestUtil.DEFAULT_DATABASE_NAME);
-        MongoCollection<Document> currentChangeLogCollection = database.getCollection(Constants.CHANGELOG_COLLECTION_NAME);
-        LegacyMigrationUtils.setUpAlreadyMigratedLegacyMigrationChange(currentChangeLogCollection, runAlways);
-        LegacyMigrationUtils.setUpLegacyMigration(database.getCollection(LegacyMigrationUtils.LEGACY_CHANGELOG_COLLECTION_NAME));
-        try {
-            Map<String, String> parameters = new HashMap<>();
-            parameters.put("mongock.changeLogsScanPackage",  EmptyChangeLog.class.getPackage().getName());
-            parameters.put("mongock.legacy-migration.origin",  LegacyMigrationUtils.LEGACY_CHANGELOG_COLLECTION_NAME);
-            parameters.put("mongock.legacy-migration.run-always",  Boolean.toString(runAlways));
-            ctx = RuntimeTestUtil.startSpringAppWithParameters(mongoContainer, parameters);
-        } catch (Exception ex) {
-            //ignore
-        }
-
-        // then
-        LegacyMigrationUtils.checkLegacyMigration(currentChangeLogCollection, runAlways, executions);
-        closeSpringApp();
-    }
+    // then
+    LegacyMigrationUtils.checkLegacyMigration(currentChangeLogCollection, runAlways, executions);
+    closeSpringApp();
+  }
 
 }

--- a/drivers/mongock-driver-mongodb/mongodb-driver-test-template/pom.xml
+++ b/drivers/mongock-driver-mongodb/mongodb-driver-test-template/pom.xml
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.15.0</version>
+      <version>1.16.2</version>
     </dependency>
   </dependencies>
 

--- a/drivers/mongock-driver-mongodb/mongodb-springdata-v2-driver/src/main/java/io/mongock/driver/mongodb/springdata/v2/SpringDataMongoV2DriverBase.java
+++ b/drivers/mongock-driver-mongodb/mongodb-springdata-v2-driver/src/main/java/io/mongock/driver/mongodb/springdata/v2/SpringDataMongoV2DriverBase.java
@@ -1,18 +1,18 @@
 package io.mongock.driver.mongodb.springdata.v2;
 
+import com.github.cloudyrock.mongock.driver.mongodb.springdata.v2.decorator.impl.MongockTemplate;
+import io.mongock.api.exception.MongockException;
 import io.mongock.driver.api.driver.ChangeSetDependency;
 import io.mongock.driver.api.driver.ChangeSetDependencyBuildable;
 import io.mongock.driver.api.driver.Transactioner;
 import io.mongock.driver.api.entry.ChangeEntryService;
-import com.github.cloudyrock.mongock.driver.mongodb.springdata.v2.decorator.impl.MongockTemplate;
 import io.mongock.driver.mongodb.v3.driver.MongoCore3DriverGeneric;
-import io.mongock.api.exception.MongockException;
 import io.mongock.utils.annotation.NotThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.SessionSynchronization;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
@@ -25,7 +25,7 @@ public abstract class SpringDataMongoV2DriverBase extends MongoCore3DriverGeneri
   protected static final Logger logger = LoggerFactory.getLogger(SpringDataMongoV2DriverBase.class);
 
   protected final MongoTemplate mongoTemplate;
-  protected MongoTransactionManager txManager;
+  protected PlatformTransactionManager txManager;
 
   protected SpringDataMongoV2DriverBase(MongoTemplate mongoTemplate,
                                     long lockAcquiredForMillis,
@@ -82,7 +82,7 @@ public abstract class SpringDataMongoV2DriverBase extends MongoCore3DriverGeneri
     this.txManager = null;
   }
 
-  public void enableTransactionWithTxManager(MongoTransactionManager txManager) {
+  public void enableTransactionWithTxManager(PlatformTransactionManager txManager) {
     this.txManager = txManager;
   }
 
@@ -106,7 +106,7 @@ public abstract class SpringDataMongoV2DriverBase extends MongoCore3DriverGeneri
 
   }
 
-  protected TransactionStatus getTxStatus(MongoTransactionManager txManager) {
+  protected TransactionStatus getTxStatus(PlatformTransactionManager txManager) {
     DefaultTransactionDefinition def = new DefaultTransactionDefinition();
 // explicitly setting the transaction name is something that can be done only programmatically
     def.setName("mongock-transaction-spring-data-3");

--- a/drivers/mongock-driver-mongodb/mongodb-springdata-v3-driver/pom.xml
+++ b/drivers/mongock-driver-mongodb/mongodb-springdata-v3-driver/pom.xml
@@ -87,6 +87,24 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <version>${spring-boot.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-sleuth-autoconfigure</artifactId>
+      <version>${spring-cloud-sleuth.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-sleuth-brave</artifactId>
+      <version>${spring-cloud-sleuth.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/drivers/mongock-driver-mongodb/mongodb-springdata-v3-driver/src/main/java/io/mongock/driver/mongodb/springdata/v3/SpringDataMongoV3DriverBase.java
+++ b/drivers/mongock-driver-mongodb/mongodb-springdata-v3-driver/src/main/java/io/mongock/driver/mongodb/springdata/v3/SpringDataMongoV3DriverBase.java
@@ -1,18 +1,18 @@
 package io.mongock.driver.mongodb.springdata.v3;
 
+import com.github.cloudyrock.mongock.driver.mongodb.springdata.v3.decorator.impl.MongockTemplate;
+import io.mongock.api.exception.MongockException;
 import io.mongock.driver.api.driver.ChangeSetDependency;
 import io.mongock.driver.api.driver.ChangeSetDependencyBuildable;
 import io.mongock.driver.api.driver.Transactioner;
 import io.mongock.driver.api.entry.ChangeEntryService;
-import com.github.cloudyrock.mongock.driver.mongodb.springdata.v3.decorator.impl.MongockTemplate;
 import io.mongock.driver.mongodb.sync.v4.driver.MongoSync4DriverGeneric;
-import io.mongock.api.exception.MongockException;
 import io.mongock.utils.annotation.NotThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.SessionSynchronization;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
@@ -25,7 +25,7 @@ public abstract class SpringDataMongoV3DriverBase extends MongoSync4DriverGeneri
   protected static final Logger logger = LoggerFactory.getLogger(SpringDataMongoV3DriverBase.class);
 
   protected final MongoTemplate mongoTemplate;
-  protected MongoTransactionManager txManager;
+  protected PlatformTransactionManager txManager;
 
   protected SpringDataMongoV3DriverBase(MongoTemplate mongoTemplate,
                                     long lockAcquiredForMillis,
@@ -84,7 +84,7 @@ public abstract class SpringDataMongoV3DriverBase extends MongoSync4DriverGeneri
     this.txManager = null;
   }
 
-  public void enableTransactionWithTxManager(MongoTransactionManager txManager) {
+  public void enableTransactionWithTxManager(PlatformTransactionManager txManager) {
     this.txManager = txManager;
   }
 
@@ -108,7 +108,7 @@ public abstract class SpringDataMongoV3DriverBase extends MongoSync4DriverGeneri
 
   }
 
-  protected TransactionStatus getTxStatus(MongoTransactionManager txManager) {
+  protected TransactionStatus getTxStatus(PlatformTransactionManager txManager) {
     DefaultTransactionDefinition def = new DefaultTransactionDefinition();
 // explicitly setting the transaction name is something that can be done only programmatically
     def.setName("mongock-transaction-spring-data-3");

--- a/drivers/mongock-driver-mongodb/mongodb-springdata-v3-driver/src/main/java/io/mongock/driver/mongodb/springdata/v3/config/SpringDataMongoV3Context.java
+++ b/drivers/mongock-driver-mongodb/mongodb-springdata-v3-driver/src/main/java/io/mongock/driver/mongodb/springdata/v3/config/SpringDataMongoV3Context.java
@@ -5,8 +5,8 @@ import io.mongock.driver.mongodb.springdata.v3.SpringDataMongoV3Driver;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
 
 import java.util.Optional;
 
@@ -19,7 +19,7 @@ public class SpringDataMongoV3Context extends SpringDataMongoV3ContextBase<Mongo
   protected SpringDataMongoV3Driver buildDriver(MongoTemplate mongoTemplate,
                                                 MongockConfiguration config,
                                                 MongoDBConfiguration mongoDbConfig,
-                                                Optional<MongoTransactionManager> txManagerOpt) {
+                                                Optional<PlatformTransactionManager> txManagerOpt) {
     return SpringDataMongoV3Driver.withLockStrategy(
         mongoTemplate,
         config.getLockAcquiredForMillis(),

--- a/drivers/mongock-driver-mongodb/mongodb-springdata-v3-driver/src/main/java/io/mongock/driver/mongodb/springdata/v3/config/SpringDataMongoV3ContextBase.java
+++ b/drivers/mongock-driver-mongodb/mongodb-springdata-v3-driver/src/main/java/io/mongock/driver/mongodb/springdata/v3/config/SpringDataMongoV3ContextBase.java
@@ -1,14 +1,14 @@
 package io.mongock.driver.mongodb.springdata.v3.config;
 
+import com.mongodb.ReadConcern;
 import io.mongock.api.config.MongockConfiguration;
 import io.mongock.driver.api.driver.ConnectionDriver;
 import io.mongock.driver.mongodb.springdata.v3.SpringDataMongoV3DriverBase;
-import com.mongodb.ReadConcern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
 
 import java.util.Optional;
 
@@ -19,7 +19,7 @@ public abstract class SpringDataMongoV3ContextBase<CONFIG extends MongockConfigu
   public ConnectionDriver connectionDriver(MongoTemplate mongoTemplate,
                                                          CONFIG config,
                                                          MongoDBConfiguration mongoDbConfig,
-                                                         Optional<MongoTransactionManager> txManagerOpt) {
+                                                         Optional<PlatformTransactionManager> txManagerOpt) {
     DRIVER driver = buildDriver(mongoTemplate, config, mongoDbConfig, txManagerOpt);
     setGenericDriverConfig(config, txManagerOpt, driver);
     setMongoDBConfig(mongoDbConfig, driver);
@@ -30,10 +30,10 @@ public abstract class SpringDataMongoV3ContextBase<CONFIG extends MongockConfigu
   protected abstract DRIVER buildDriver(MongoTemplate mongoTemplate,
                                         CONFIG config,
                                         MongoDBConfiguration mongoDbConfig,
-                                        Optional<MongoTransactionManager> txManagerOpt);
+                                        Optional<PlatformTransactionManager> txManagerOpt);
 
   private void setGenericDriverConfig(CONFIG config,
-                                      Optional<MongoTransactionManager> txManagerOpt,
+                                      Optional<PlatformTransactionManager> txManagerOpt,
                                       DRIVER driver) {
     txManagerOpt.ifPresent(driver::enableTransactionWithTxManager);
     driver.setChangeLogRepositoryName(config.getChangeLogRepositoryName());

--- a/drivers/mongock-driver-mongodb/mongodb-springdata-v3-driver/src/test/java/io/mongock/driver/mongodb/springdata/v3/SpringDataMongoV3ContextTest.java
+++ b/drivers/mongock-driver-mongodb/mongodb-springdata-v3-driver/src/test/java/io/mongock/driver/mongodb/springdata/v3/SpringDataMongoV3ContextTest.java
@@ -1,22 +1,22 @@
 package io.mongock.driver.mongodb.springdata.v3;
 
 
-import io.mongock.api.config.MongockConfiguration;
-import io.mongock.driver.mongodb.springdata.v3.config.MongoDBConfiguration;
-import io.mongock.driver.mongodb.springdata.v3.config.SpringDataMongoV3Context;
-import io.mongock.driver.mongodb.sync.v4.repository.MongoSync4RepositoryBase;
-import io.mongock.driver.mongodb.sync.v4.repository.util.RepositoryAccessorHelper;
 import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
+import io.mongock.api.config.MongockConfiguration;
+import io.mongock.driver.mongodb.springdata.v3.config.MongoDBConfiguration;
+import io.mongock.driver.mongodb.springdata.v3.config.SpringDataMongoV3Context;
+import io.mongock.driver.mongodb.sync.v4.repository.MongoSync4RepositoryBase;
+import io.mongock.driver.mongodb.sync.v4.repository.util.RepositoryAccessorHelper;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
 
 import java.util.Optional;
 
@@ -26,7 +26,7 @@ public class SpringDataMongoV3ContextTest {
   /**
    * public ConnectionDriver connectionDriver(MongoTemplate mongoTemplate,
    *                                            SpringMongoDBConfiguration config,
-   *                                            Optional<MongoTransactionManager> txManagerOpt)
+   *                                            Optional<PlatformTransactionManager> txManagerOpt)
    */
 
 
@@ -36,7 +36,7 @@ public class SpringDataMongoV3ContextTest {
   public void shouldCreateDefaultReadWriteConcerns_whenCreating_ifNoParams() {
     MongoTemplate mongoTemplate = Mockito.mock(MongoTemplate.class);
     Mockito.when(mongoTemplate.getDb()).thenReturn(Mockito.mock(MongoDatabase.class));
-    Optional<MongoTransactionManager> opt = Optional.empty();
+    Optional<PlatformTransactionManager> opt = Optional.empty();
 
     MongockConfiguration config = Mockito.spy(new MongockConfiguration());
     MongoDBConfiguration mongoDbConfig = Mockito.spy(new MongoDBConfiguration());

--- a/drivers/mongock-driver-mongodb/mongodb-springdata-v3-driver/src/test/java/io/mongock/driver/mongodb/springdata/v3/config/SpringDataMongoV3ContextTest.java
+++ b/drivers/mongock-driver-mongodb/mongodb-springdata-v3-driver/src/test/java/io/mongock/driver/mongodb/springdata/v3/config/SpringDataMongoV3ContextTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © Ericsson AB 2021.
+ *
+ * All Rights Reserved.
+ *
+ * Reproduction in whole or in part is prohibited without the written consent of the copyright owner.
+ *
+ */
+
+package io.mongock.driver.mongodb.springdata.v3.config;
+
+import com.mongodb.client.MongoClients;
+import io.mongock.api.config.MongockConfiguration;
+import io.mongock.driver.api.driver.ConnectionDriver;
+import io.mongock.driver.mongodb.springdata.v3.SpringDataMongoV3Driver;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.sleuth.autoconfig.brave.BraveAutoConfiguration;
+import org.springframework.cloud.sleuth.autoconfig.instrument.config.TraceSpringCloudConfigAutoConfiguration;
+import org.springframework.cloud.sleuth.autoconfig.instrument.mongodb.TraceMongoDbAutoConfiguration;
+import org.springframework.cloud.sleuth.autoconfig.instrument.tx.TraceTxAutoConfiguration;
+import org.springframework.cloud.sleuth.instrument.tx.TracePlatformTransactionManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoTransactionManager;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SpringDataMongoV3ContextTest {
+  @Test
+  public void withoutSleuth() {
+    ApplicationContextRunner applicationContextRunner = new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(
+            MongockConfiguration.class,
+            MongoTxConfiguration.class,
+            SpringDataMongoV3Context.class,
+            MongoAutoConfiguration.class,
+            MongoDataAutoConfiguration.class));
+    applicationContextRunner.run((context) -> assertThat(context)
+        .hasSingleBean(MongoTransactionManager.class)
+        .hasSingleBean(MongoTemplate.class)
+        .hasSingleBean(ConnectionDriver.class));
+  }
+
+  @Test
+  public void withSleuth() {
+    ApplicationContextRunner applicationContextRunner = new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(
+            MongockConfiguration.class,
+            MongoTxConfiguration.class,
+            SpringDataMongoV3Context.class,
+            MongoAutoConfiguration.class,
+            MongoDataAutoConfiguration.class,
+            TraceMongoDbAutoConfiguration.class,
+            TraceSpringCloudConfigAutoConfiguration.class,
+            BraveAutoConfiguration.class,
+            TraceTxAutoConfiguration.class));
+    applicationContextRunner.run((context) -> assertThat(context)
+        .hasSingleBean(TracePlatformTransactionManager.class)
+        .hasSingleBean(MongoTemplate.class)
+        .hasSingleBean(ConnectionDriver.class));
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  static class MongoTxConfiguration {
+    @Bean
+    public MongoTransactionManager transactionManager(MongoDatabaseFactory dbFactory) {
+      return new MongoTransactionManager(dbFactory);
+    }
+  }
+}

--- a/drivers/mongock-driver-mongodb/pom.xml
+++ b/drivers/mongock-driver-mongodb/pom.xml
@@ -29,6 +29,7 @@
   <properties>
 
     <spring-boot.version>[2.0.0, 3.0.0)</spring-boot.version>
+    <spring-cloud-sleuth.version>3.1.0</spring-cloud-sleuth.version>
     <spring-data-3.version>3.2.5</spring-data-3.version>
     <spring-data-3.mongodb.version>4.2.3</spring-data-3.mongodb.version>
 


### PR DESCRIPTION
## Issue reference

https://github.com/mongock/mongock/issues/455

## Documentation PR reference

n/a

## Description and context

use `PlatformTransactionManager` instead `MongoTransactionManager` in order to support sleuth tracing transation manager

## Benefits

support sleuth

## Possible Drawbacks

should not

## Checklist 
- [ ] Unit tests provided
- [ ] Integration tests provided 
- [ ] Documentation updated in [documentation project](https://github.com/mongock/mongock-docs)
- [ ] Updated example in [example projects](https://github.com/mongock/mongock-examples)

