### PR TITLE
refactor/change_entry_order_by_original_timestamp

### DIFF
--- a/drivers/mongock-driver-mongodb/mongodb-sync-v4-driver/src/test/java/io/mongock/driver/mongodb/sync/v4/changelogs/LegacyServiceTest.java
+++ b/drivers/mongock-driver-mongodb/mongodb-sync-v4-driver/src/test/java/io/mongock/driver/mongodb/sync/v4/changelogs/LegacyServiceTest.java
@@ -9,7 +9,7 @@ import io.mongock.api.config.LegacyMigration;
 import io.mongock.api.config.LegacyMigrationMappingFields;
 import io.mongock.driver.api.entry.ChangeEntry;
 import io.mongock.driver.api.entry.ChangeEntryService;
-import io.mongock.driver.api.entry.ExecutedChangeEntry;
+import io.mongock.driver.api.entry.ChangeEntryExecuted;
 import org.bson.Document;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -63,8 +63,8 @@ public class LegacyServiceTest {
     ChangeEntry c1 = getChangeEntry(1);//from legacy and NOT executed(NOT OK)
     ChangeEntry c2 = getChangeEntry(2);//from legacy and executed(OK)
     ChangeEntry c3 = getChangeEntry(3);//not from legacy
-    ExecutedChangeEntry c2Ex = new ExecutedChangeEntry(c2);
-    ExecutedChangeEntry c3Ex = new ExecutedChangeEntry(c3);
+    ChangeEntryExecuted c2Ex = new ChangeEntryExecuted(c2);
+    ChangeEntryExecuted c3Ex = new ChangeEntryExecuted(c3);
 
     when(service.getEntriesLog()).thenReturn(Arrays.asList(c1, c2, c3));
 

--- a/mongock-core/mongock-driver/mongock-driver-api/src/main/java/io/mongock/driver/api/entry/ChangeEntry.java
+++ b/mongock-core/mongock-driver/mongock-driver-api/src/main/java/io/mongock/driver/api/entry/ChangeEntry.java
@@ -118,7 +118,7 @@ public class ChangeEntry implements ChangePrintable {
     this.executionHostname = executionHostname;
     this.metadata = metadata;
     this.errorTrace = errorTrace;
-    this.originalTimestamp = null;
+    this.originalTimestamp = null;//TODO: To be assigned when we could save value en DB
   }
 
 

--- a/mongock-core/mongock-driver/mongock-driver-api/src/main/java/io/mongock/driver/api/entry/ChangeEntry.java
+++ b/mongock-core/mongock-driver/mongock-driver-api/src/main/java/io/mongock/driver/api/entry/ChangeEntry.java
@@ -16,7 +16,6 @@ import static io.mongock.driver.api.entry.ChangeState.EXECUTED;
 import static io.mongock.driver.api.entry.ChangeState.FAILED;
 import static io.mongock.driver.api.entry.ChangeState.ROLLBACK_FAILED;
 import static io.mongock.driver.api.entry.ChangeState.ROLLED_BACK;
-import static io.mongock.driver.api.entry.ChangeType.BEFORE_EXECUTION;
 import static io.mongock.utils.field.Field.KeyType.PRIMARY;
 
 /**
@@ -76,6 +75,8 @@ public class ChangeEntry implements ChangePrintable {
 
   @Field(KEY_ERROR_TRACE)
   protected String errorTrace;
+  
+  protected Date originalTimestamp;
 
   public ChangeEntry() {}
 
@@ -117,6 +118,7 @@ public class ChangeEntry implements ChangePrintable {
     this.executionHostname = executionHostname;
     this.metadata = metadata;
     this.errorTrace = errorTrace;
+    this.originalTimestamp = null;
   }
 
 
@@ -236,6 +238,14 @@ public class ChangeEntry implements ChangePrintable {
 
   public Optional<String> getErrorTrace() {
     return Optional.ofNullable(errorTrace);
+  }
+  
+  public Date getOriginalTimestamp() {
+    return this.originalTimestamp;
+  }
+  
+  public void setOriginalTimestamp(Date originalTimestamp) {
+    this.originalTimestamp = originalTimestamp;
   }
 
   @Override

--- a/mongock-core/mongock-driver/mongock-driver-api/src/main/java/io/mongock/driver/api/entry/ChangeEntryExecuted.java
+++ b/mongock-core/mongock-driver/mongock-driver-api/src/main/java/io/mongock/driver/api/entry/ChangeEntryExecuted.java
@@ -2,7 +2,7 @@ package io.mongock.driver.api.entry;
 
 import java.util.Date;
 
-public class ExecutedChangeEntry {
+public class ChangeEntryExecuted {
 
   private final String changeId;
 
@@ -14,7 +14,7 @@ public class ExecutedChangeEntry {
 
   private final String changeSetMethod;
 
-  public ExecutedChangeEntry(
+  public ChangeEntryExecuted(
                      String changeId,
                      String author,
                      Date timestamp,
@@ -26,7 +26,7 @@ public class ExecutedChangeEntry {
     this.changeLogClass = changeLogClass;
     this.changeSetMethod = changeSetMethod;
   }
-  public ExecutedChangeEntry(ChangeEntry entry) {
+  public ChangeEntryExecuted(ChangeEntry entry) {
     this(entry.getChangeId(), entry.getAuthor(), entry.getTimestamp(), entry.getChangeLogClass(), entry.getChangeSetMethod());
   }
 
@@ -52,7 +52,7 @@ public class ExecutedChangeEntry {
 
   @Override
   public String toString() {
-    return "ExecutedChangeEntry{" +
+    return "ChangeEntryExecuted{" +
         "changeId='" + changeId + '\'' +
         ", author='" + author + '\'' +
         ", timestamp=" + timestamp +

--- a/mongock-core/mongock-driver/mongock-driver-api/src/test/java/io/mongock/driver/api/entry/ChangeEntryServiceTest.java
+++ b/mongock-core/mongock-driver/mongock-driver-api/src/test/java/io/mongock/driver/api/entry/ChangeEntryServiceTest.java
@@ -71,8 +71,8 @@ public class ChangeEntryServiceTest {
   public void getExecuted() {
 
     ChangeEntryServiceImpl entryService = getChangeEntryService();
-    List<ExecutedChangeEntry> result = entryService.getExecuted();
-    result.sort(Comparator.comparing(ExecutedChangeEntry::getChangeId));
+    List<ChangeEntryExecuted> result = entryService.getExecuted();
+    result.sort(Comparator.comparing(ChangeEntryExecuted::getChangeId));
 
     assertEquals("change-1", result.get(0).getChangeId());
     assertEquals("change-2", result.get(1).getChangeId());

--- a/mongock-core/mongock-driver/mongock-driver-core/src/test/java/io/mongock/driver/core/lock/DefaultLockManagerTest.java
+++ b/mongock-core/mongock-driver/mongock-driver-core/src/test/java/io/mongock/driver/core/lock/DefaultLockManagerTest.java
@@ -516,7 +516,7 @@ public class DefaultLockManagerTest {
     //when
     lockManager.acquireLockDefault();
     lockManager.releaseLockDefault();
-    lockManager.acquireLockDefault();
+    lockManager.acquireLockDefault();//TODO: Randomly produces a race condition by calling twice "lockRepository.removeByKeyAndOwner" (maybe LockDaemon)
 
     //then
     verify(lockRepository).removeByKeyAndOwner(lockManager.getDefaultKey(), lockManager.getOwner());

--- a/mongock-core/mongock-runner/mongock-runner-core/src/main/java/io/mongock/runner/core/executor/operation/change/MigrationExecutorBase.java
+++ b/mongock-core/mongock-runner/mongock-runner-core/src/main/java/io/mongock/runner/core/executor/operation/change/MigrationExecutorBase.java
@@ -9,7 +9,7 @@ import io.mongock.driver.api.driver.ConnectionDriver;
 import io.mongock.driver.api.entry.ChangeEntry;
 import io.mongock.driver.api.entry.ChangeState;
 import io.mongock.driver.api.entry.ChangeType;
-import io.mongock.driver.api.entry.ExecutedChangeEntry;
+import io.mongock.driver.api.entry.ChangeEntryExecuted;
 import io.mongock.driver.api.lock.LockManager;
 import io.mongock.runner.core.executor.Executor;
 import io.mongock.runner.core.executor.NonTransactioner;
@@ -60,7 +60,7 @@ public abstract class MigrationExecutorBase<CONFIG extends ChangeExecutorConfigu
   protected boolean executionInProgress = false;
   protected final String executionId;
   private final TransactionStrategy transactionStrategy;
-  protected List<ExecutedChangeEntry> executedChangeEntries = null;
+  protected List<ChangeEntryExecuted> executedChangeEntries = null;
 
 
   public MigrationExecutorBase(String executionId,

--- a/mongock-core/mongock-runner/mongock-runner-core/src/test/java/io/mongock/runner/core/executor/ChangeUnitExecutorImplTest.java
+++ b/mongock-core/mongock-runner/mongock-runner-core/src/test/java/io/mongock/runner/core/executor/ChangeUnitExecutorImplTest.java
@@ -11,7 +11,7 @@ import io.mongock.driver.api.driver.ConnectionDriver;
 import io.mongock.driver.api.entry.ChangeEntry;
 import io.mongock.driver.api.entry.ChangeEntryService;
 import io.mongock.driver.api.entry.ChangeState;
-import io.mongock.driver.api.entry.ExecutedChangeEntry;
+import io.mongock.driver.api.entry.ChangeEntryExecuted;
 import io.mongock.driver.api.lock.LockManager;
 import io.mongock.runner.core.changelogs.executor.test1.ExecutorChangeLog;
 import io.mongock.runner.core.changelogs.executor.test3_with_nonFailFast.ExecutorWithNonFailFastChangeLog;
@@ -110,8 +110,8 @@ public class ChangeUnitExecutorImplTest {
         .thenReturn(Collections.emptyList())
         .thenReturn(Collections.emptyList())
         .thenReturn(Arrays.asList(
-            generateExecutedChangeEntry("system-change-unit", "mongock_test"),
-            generateExecutedChangeEntry("new-change-unit", "mongock_test")));
+            generateChangeEntryExecuted("system-change-unit", "mongock_test"),
+            generateChangeEntryExecuted("new-change-unit", "mongock_test")));
     new MigrationExecutor(
         "",
         createInitialChangeLogsByPackage(SystemChangeUnit.class),
@@ -129,7 +129,7 @@ public class ChangeUnitExecutorImplTest {
 
     // given
     injectDummyDependency(DummyDependencyClass.class, new DummyDependencyClass());
-    when(changeEntryService.getExecuted()).thenReturn(Collections.singletonList(generateExecutedChangeEntry("alreadyExecuted", "executor")));
+    when(changeEntryService.getExecuted()).thenReturn(Collections.singletonList(generateChangeEntryExecuted("alreadyExecuted", "executor")));
 
     // when
     MongockConfiguration config = new MongockConfiguration();
@@ -192,7 +192,7 @@ public class ChangeUnitExecutorImplTest {
   public void shouldAbortMigrationButSaveFailedChangeSet_IfChangeSetThrowsException() throws InterruptedException {
     // given
     injectDummyDependency(DummyDependencyClass.class, new DummyDependencyClass());
-    when(changeEntryService.getExecuted()).thenReturn(Arrays.asList(generateExecutedChangeEntry("runAlwaysAndAlreadyExecutedChangeSet", "executor")));
+    when(changeEntryService.getExecuted()).thenReturn(Arrays.asList(generateChangeEntryExecuted("runAlwaysAndAlreadyExecutedChangeSet", "executor")));
 
     // when
     try {
@@ -478,8 +478,8 @@ public class ChangeUnitExecutorImplTest {
   public void shouldReturnProxy_IfStandardDependency() {
     // given
     when(changeEntryService.getExecuted()).thenReturn(Arrays.asList(
-        generateExecutedChangeEntry("withInterfaceParameter2", "executor"),
-        generateExecutedChangeEntry("withNonLockGuardedParameter", "executor")
+        generateChangeEntryExecuted("withInterfaceParameter2", "executor"),
+        generateChangeEntryExecuted("withNonLockGuardedParameter", "executor")
     ));
 
     // when
@@ -502,8 +502,8 @@ public class ChangeUnitExecutorImplTest {
   public void proxyReturnedShouldReturnAProxy_whenCallingAMethod_IfInterface() {
     // given
     when(changeEntryService.getExecuted()).thenReturn(Arrays.asList(
-        generateExecutedChangeEntry("withInterfaceParameter", "executor"),
-        generateExecutedChangeEntry("withNonLockGuardedParameter", "executor")
+        generateChangeEntryExecuted("withInterfaceParameter", "executor"),
+        generateChangeEntryExecuted("withNonLockGuardedParameter", "executor")
     ));
 
     // when
@@ -526,8 +526,8 @@ public class ChangeUnitExecutorImplTest {
   public void shouldNotReturnProxy_IfClassAnnotatedWithNonLockGuarded() {
     // given
     when(changeEntryService.getExecuted()).thenReturn(Arrays.asList(
-        generateExecutedChangeEntry("withInterfaceParameter2", "executor"),
-        generateExecutedChangeEntry("withNonLockGuardedParameter", "executor")
+        generateChangeEntryExecuted("withInterfaceParameter2", "executor"),
+        generateChangeEntryExecuted("withNonLockGuardedParameter", "executor")
     ));
 
     // when
@@ -550,8 +550,8 @@ public class ChangeUnitExecutorImplTest {
   public void shouldNotReturnProxy_IfParameterAnnotatedWithNonLockGuarded() {
     // given
     when(changeEntryService.getExecuted()).thenReturn(Arrays.asList(
-        generateExecutedChangeEntry("withInterfaceParameter", "executor"),
-        generateExecutedChangeEntry("withInterfaceParameter2", "executor")
+        generateChangeEntryExecuted("withInterfaceParameter", "executor"),
+        generateChangeEntryExecuted("withInterfaceParameter2", "executor")
     ));
 
     // when
@@ -626,8 +626,8 @@ public class ChangeUnitExecutorImplTest {
   public void shouldSkipMigration_whenAllChangeSetItemsAlreadyExecuted() {
     // given
     when(changeEntryService.getExecuted()).thenReturn(Arrays.asList(
-        generateExecutedChangeEntry("alreadyExecuted", "executor"),
-        generateExecutedChangeEntry("alreadyExecuted2", "executor")
+        generateChangeEntryExecuted("alreadyExecuted", "executor"),
+        generateChangeEntryExecuted("alreadyExecuted2", "executor")
     ));
 
     when(driver.getLockManager()).thenReturn(lockManager);
@@ -651,8 +651,8 @@ public class ChangeUnitExecutorImplTest {
     // given
     injectDummyDependency(DummyDependencyClass.class, new DummyDependencyClass());
     when(changeEntryService.getExecuted()).thenReturn(Arrays.asList(
-        generateExecutedChangeEntry("alreadyExecuted", "executor"),
-        generateExecutedChangeEntry("alreadyExecuted2", "executor")
+        generateChangeEntryExecuted("alreadyExecuted", "executor"),
+        generateChangeEntryExecuted("alreadyExecuted2", "executor")
     ));
 
     when(driver.getLockManager()).thenReturn(lockManager);
@@ -679,9 +679,9 @@ public class ChangeUnitExecutorImplTest {
     // given
     injectDummyDependency(DummyDependencyClass.class, new DummyDependencyClass());
     when(changeEntryService.getExecuted()).thenReturn(Arrays.asList(
-        generateExecutedChangeEntry("alreadyExecuted", "executor"),
-        generateExecutedChangeEntry("alreadyExecuted2", "executor"),
-        generateExecutedChangeEntry("alreadyExecutedRunAlways", "executor")
+        generateChangeEntryExecuted("alreadyExecuted", "executor"),
+        generateChangeEntryExecuted("alreadyExecuted2", "executor"),
+        generateChangeEntryExecuted("alreadyExecutedRunAlways", "executor")
     ));
 
     when(driver.getLockManager()).thenReturn(lockManager);
@@ -990,7 +990,7 @@ public class ChangeUnitExecutorImplTest {
   private abstract static class TransactionableConnectionDriver implements ConnectionDriver {
   }
 
-  private ExecutedChangeEntry generateExecutedChangeEntry(String changeId, String author) {
-    return new ExecutedChangeEntry(changeId, author, new Date(), "dummy", "dummy");
+  private ChangeEntryExecuted generateChangeEntryExecuted(String changeId, String author) {
+    return new ChangeEntryExecuted(changeId, author, new Date(), "dummy", "dummy");
   }
 }

--- a/mongock-core/mongock-runner/spring/springboot/mongock-springboot/src/test/java/io/mongock/runner/springboot/SpringMongockApplicationRunnerBaseTest.java
+++ b/mongock-core/mongock-runner/spring/springboot/mongock-springboot/src/test/java/io/mongock/runner/springboot/SpringMongockApplicationRunnerBaseTest.java
@@ -6,7 +6,7 @@ import io.mongock.driver.api.driver.ChangeSetDependency;
 import io.mongock.driver.api.driver.ConnectionDriver;
 import io.mongock.driver.api.entry.ChangeEntry;
 import io.mongock.driver.api.entry.ChangeEntryService;
-import io.mongock.driver.api.entry.ExecutedChangeEntry;
+import io.mongock.driver.api.entry.ChangeEntryExecuted;
 import io.mongock.driver.api.lock.LockManager;
 import io.mongock.runner.springboot.profiles.enseuredecorators.EnsureDecoratorChangerLog;
 import io.mongock.runner.springboot.profiles.integration.IntegrationProfiledChangerLog;
@@ -140,8 +140,8 @@ public class SpringMongockApplicationRunnerBaseTest {
   public void shouldReturnProxy_IfStandardDependency() throws Exception {
     // given
     when(changeEntryService.getExecuted()).thenReturn(Arrays.asList(
-            generateExecutedChangeEntry("withInterfaceParameter2", "executor"),
-            generateExecutedChangeEntry("withClassNotInterfacedParameter", "executor")
+            generateChangeEntryExecuted("withInterfaceParameter2", "executor"),
+            generateChangeEntryExecuted("withClassNotInterfacedParameter", "executor")
     ));
 
     // when
@@ -155,8 +155,8 @@ public class SpringMongockApplicationRunnerBaseTest {
   public void proxyReturnedShouldReturnAProxy_whenCallingAMethod_IfInterface() throws Exception {
     // given
     when(changeEntryService.getExecuted()).thenReturn(Arrays.asList(
-            generateExecutedChangeEntry("withInterfaceParameter", "executor"),
-            generateExecutedChangeEntry("withClassNotInterfacedParameter", "executor")
+            generateChangeEntryExecuted("withInterfaceParameter", "executor"),
+            generateChangeEntryExecuted("withClassNotInterfacedParameter", "executor")
     ));
 
     // when
@@ -171,8 +171,8 @@ public class SpringMongockApplicationRunnerBaseTest {
   public void shouldNotReturnProxy_IfClassAnnotatedWithNonLockGuarded() throws Exception {
     // given
     when(changeEntryService.getExecuted()).thenReturn(Arrays.asList(
-            generateExecutedChangeEntry("withInterfaceParameter2", "executor"),
-            generateExecutedChangeEntry("withClassNotInterfacedParameter", "executor")
+            generateChangeEntryExecuted("withInterfaceParameter2", "executor"),
+            generateChangeEntryExecuted("withClassNotInterfacedParameter", "executor")
     ));
     when(springContext.getBean(InterfaceDependency.class)).thenReturn(new InterfaceDependencyImplNoLockGarded());
 
@@ -188,9 +188,9 @@ public class SpringMongockApplicationRunnerBaseTest {
   public void shouldNotReturnProxy_IfParameterAnnotatedWithNonLockGuarded() throws Exception {
     // given
     when(changeEntryService.getExecuted()).thenReturn(Arrays.asList(
-            generateExecutedChangeEntry("withInterfaceParameter", "executor"),
-            generateExecutedChangeEntry("withInterfaceParameter2", "executor"),
-            generateExecutedChangeEntry("withClassNotInterfacedParameter", "executor")
+            generateChangeEntryExecuted("withInterfaceParameter", "executor"),
+            generateChangeEntryExecuted("withInterfaceParameter2", "executor"),
+            generateChangeEntryExecuted("withClassNotInterfacedParameter", "executor")
     ));
 
     // when
@@ -204,14 +204,14 @@ public class SpringMongockApplicationRunnerBaseTest {
     MongockSpringboot
         .builder()
         .setDriver(driver)
-        .addChangeLogsScanPackage(packageName)
+        .addMigrationScanPackage(packageName)
         .setSpringContext(springContext)
         .buildApplicationRunner()
         .run(null);
 
   }
   
-  private ExecutedChangeEntry generateExecutedChangeEntry(String changeId, String author) {
-    return new ExecutedChangeEntry(changeId, author, new Date(), "dummy", "dummy");
+  private ChangeEntryExecuted generateChangeEntryExecuted(String changeId, String author) {
+    return new ChangeEntryExecuted(changeId, author, new Date(), "dummy", "dummy");
   }
 }


### PR DESCRIPTION
Added "originalTimestamp" field (transient for now), to order changeEntries by oldest timestamp that exists in db.
Also renamed class "ExecutedChangeEntry" to "ChangeEntryExecuted" for better maintenance.