### PR TITLE
Add ChangeUnitConstructor annotation to allow mongock to pick constructors for dependency injection

### DIFF
--- a/mongock-core/mongock-api/src/main/java/io/mongock/api/annotations/ChangeUnit.java
+++ b/mongock-core/mongock-api/src/main/java/io/mongock/api/annotations/ChangeUnit.java
@@ -18,6 +18,7 @@ import java.lang.annotation.Target;
  * The concept is basically the same, a class that wraps the logic of the migration
  * <p>
  * Classes annotated with @ChangeUnit must have the following:
+ * - One(and only one) one valid constructor annotated with @ChangeUnitConstructor(mandatory if more than one constructor exist)
  * - One(and only one) method annotated with @Execution(mandatory)
  * - One(and only one) method annotated with @RollbackExecution(mandatory)
  * - At most, one method annotated with @BeforeExecution(optional)
@@ -28,6 +29,7 @@ import java.lang.annotation.Target;
  * <p>
  * - For new changeLogs/changeSets created  from version 5: Annotated you class migration class with the annotation @ChangeUnit
  *
+ * @see ChangeUnitConstructor
  * @see Execution
  * @see BeforeExecution
  * @see RollbackExecution

--- a/mongock-core/mongock-api/src/main/java/io/mongock/api/annotations/ChangeUnit.java
+++ b/mongock-core/mongock-api/src/main/java/io/mongock/api/annotations/ChangeUnit.java
@@ -18,7 +18,7 @@ import java.lang.annotation.Target;
  * The concept is basically the same, a class that wraps the logic of the migration
  * <p>
  * Classes annotated with @ChangeUnit must have the following:
- * - One(and only one) one valid constructor annotated with @ChangeUnitConstructor(mandatory if more than one constructor exist)
+ * - One(and only one) one valid constructor annotated with @ChangeUnitConstructor(mandatory if more than one constructor exist after version 6)
  * - One(and only one) method annotated with @Execution(mandatory)
  * - One(and only one) method annotated with @RollbackExecution(mandatory)
  * - At most, one method annotated with @BeforeExecution(optional)

--- a/mongock-core/mongock-api/src/main/java/io/mongock/api/annotations/ChangeUnitConstructor.java
+++ b/mongock-core/mongock-api/src/main/java/io/mongock/api/annotations/ChangeUnitConstructor.java
@@ -1,0 +1,11 @@
+package io.mongock.api.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.CONSTRUCTOR)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ChangeUnitConstructor {
+}

--- a/mongock-core/mongock-runner/mongock-runner-core/src/main/java/io/mongock/runner/core/executor/ChangeLogRuntimeImpl.java
+++ b/mongock-core/mongock-runner/mongock-runner-core/src/main/java/io/mongock/runner/core/executor/ChangeLogRuntimeImpl.java
@@ -129,9 +129,14 @@ public class ChangeLogRuntimeImpl implements ChangeLogRuntime {
   }
 
   private Constructor<?> findDefaultConstructor(Class<?> type) {
-    return Optional.of(type.getConstructors())
-        .map(Arrays::stream)
-        .flatMap(Stream::findFirst)
+    Supplier<Stream<Constructor<?>>> constructorSupplier = () -> Arrays.stream(type.getConstructors());
+    if (constructorSupplier.get().count() > 1) {
+      logger.warn("Mongock found multiple constructors for changeUnit[{}]. " +
+          "It's recommended to annotate the one you want Mongock to use with @ChangeUnitConstructor. " +
+          "FROM VERSION 6 THIS WILL CAUSE AN ERROR ", type.getName());
+    }
+    return constructorSupplier.get()
+        .findFirst()
         .orElseThrow(() -> new MongockException("Mongock cannot find a valid constructor for changeUnit[%s]", type.getName()));
   }
 

--- a/mongock-core/mongock-runner/mongock-runner-core/src/main/java/io/mongock/runner/core/executor/ChangeLogRuntimeImpl.java
+++ b/mongock-core/mongock-runner/mongock-runner-core/src/main/java/io/mongock/runner/core/executor/ChangeLogRuntimeImpl.java
@@ -129,15 +129,16 @@ public class ChangeLogRuntimeImpl implements ChangeLogRuntime {
   }
 
   private Constructor<?> findDefaultConstructor(Class<?> type) {
-    Supplier<Stream<Constructor<?>>> constructorSupplier = () -> Arrays.stream(type.getConstructors());
-    if (constructorSupplier.get().count() > 1) {
+    Constructor<?>[] constructors = type.getConstructors();
+    if (constructors.length == 0) {
+      throw new MongockException("Mongock cannot find a valid constructor for changeUnit[%s]", type.getName());
+    }
+    if (constructors.length > 1) {
       logger.warn("Mongock found multiple constructors for changeUnit[{}]. " +
           "It's recommended to annotate the one you want Mongock to use with @ChangeUnitConstructor. " +
           "FROM VERSION 6 THIS WILL CAUSE AN ERROR ", type.getName());
     }
-    return constructorSupplier.get()
-        .findFirst()
-        .orElseThrow(() -> new MongockException("Mongock cannot find a valid constructor for changeUnit[%s]", type.getName()));
+    return constructors[0];
   }
 
   private Optional<Constructor<?>> findChangeUnitConstructor(Class<?> type) {

--- a/mongock-core/mongock-runner/mongock-runner-core/src/main/java/io/mongock/runner/core/executor/ChangeLogRuntimeImpl.java
+++ b/mongock-core/mongock-runner/mongock-runner-core/src/main/java/io/mongock/runner/core/executor/ChangeLogRuntimeImpl.java
@@ -124,7 +124,7 @@ public class ChangeLogRuntimeImpl implements ChangeLogRuntime {
 
 
   private Constructor<?> getConstructor(Class<?> type) {
-    return findChangeUnitConstructor(type, type.getName())
+    return findChangeUnitConstructor(type)
         .orElseGet(() -> findDefaultConstructor(type));
   }
 
@@ -140,12 +140,12 @@ public class ChangeLogRuntimeImpl implements ChangeLogRuntime {
         .orElseThrow(() -> new MongockException("Mongock cannot find a valid constructor for changeUnit[%s]", type.getName()));
   }
 
-  private Optional<Constructor<?>> findChangeUnitConstructor(Class<?> type, String className) {
+  private Optional<Constructor<?>> findChangeUnitConstructor(Class<?> type) {
     Supplier<Stream<Constructor<?>>> changeUnitConstructorsSupplier = () -> Arrays.stream(type.getConstructors())
         .filter(constructor -> constructor.isAnnotationPresent(ChangeUnitConstructor.class));
     if (changeUnitConstructorsSupplier.get().count() > 1) {
       throw new MongockException("Found multiple constructors for changeUnit[%s] without annotation @ChangeUnitConstructor." +
-          " Annotate the one you want Mongock to use to instantiate your changeUnit", className);
+          " Annotate the one you want Mongock to use to instantiate your changeUnit", type.getName());
     }
     return changeUnitConstructorsSupplier.get().findFirst();
   }

--- a/mongock-core/mongock-runner/mongock-runner-core/src/main/java/io/mongock/runner/core/executor/ChangeLogRuntimeImpl.java
+++ b/mongock-core/mongock-runner/mongock-runner-core/src/main/java/io/mongock/runner/core/executor/ChangeLogRuntimeImpl.java
@@ -1,7 +1,6 @@
 package io.mongock.runner.core.executor;
 
 import io.changock.migration.api.annotations.NonLockGuarded;
-
 import io.mongock.api.annotations.ChangeUnit;
 import io.mongock.api.exception.MongockException;
 import io.mongock.driver.api.common.DependencyInjectionException;
@@ -20,10 +19,13 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 public class ChangeLogRuntimeImpl implements ChangeLogRuntime {
   private static final Logger logger = LoggerFactory.getLogger(ChangeLogRuntimeImpl.class);
@@ -120,6 +122,9 @@ public class ChangeLogRuntimeImpl implements ChangeLogRuntime {
 
 
   private Constructor<?> getConstructor(Class<?> type) {
-    return type.getConstructors()[0];
+    return Optional.of(type.getConstructors())
+        .map(Arrays::stream)
+        .flatMap(Stream::findFirst)
+        .orElseThrow(() -> new MongockException("Mongock cannot find a valid constructor for changeUnit[%s]", type.getName()));
   }
 }

--- a/mongock-core/mongock-runner/mongock-runner-core/src/test/java/io/mongock/runner/core/changelogs/withConstructor/ChangeUnitWithDefaultConstructor.java
+++ b/mongock-core/mongock-runner/mongock-runner-core/src/test/java/io/mongock/runner/core/changelogs/withConstructor/ChangeUnitWithDefaultConstructor.java
@@ -1,0 +1,17 @@
+package io.mongock.runner.core.changelogs.withConstructor;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+
+@ChangeUnit(id = "ChangeUnitWithDefaultConstructor", order = "1")
+public class ChangeUnitWithDefaultConstructor {
+
+  @Execution
+  public void execution() {
+  }
+
+  @RollbackExecution
+  public void rollbackExecution() {
+  }
+}

--- a/mongock-core/mongock-runner/mongock-runner-core/src/test/java/io/mongock/runner/core/changelogs/withConstructor/ChangeUnitWithMoreThanOneChangeUnitConstructor.java
+++ b/mongock-core/mongock-runner/mongock-runner-core/src/test/java/io/mongock/runner/core/changelogs/withConstructor/ChangeUnitWithMoreThanOneChangeUnitConstructor.java
@@ -1,0 +1,26 @@
+package io.mongock.runner.core.changelogs.withConstructor;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.ChangeUnitConstructor;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+
+@ChangeUnit(id = "ChangeUnitWithMoreThanOneChangeUnitConstructor", order = "1")
+public class ChangeUnitWithMoreThanOneChangeUnitConstructor {
+
+  @ChangeUnitConstructor
+  public ChangeUnitWithMoreThanOneChangeUnitConstructor() {
+  }
+
+  @ChangeUnitConstructor
+  public ChangeUnitWithMoreThanOneChangeUnitConstructor(String dummy) {
+  }
+
+  @Execution
+  public void execution() {
+  }
+
+  @RollbackExecution
+  public void rollbackExecution() {
+  }
+}

--- a/mongock-core/mongock-runner/mongock-runner-core/src/test/java/io/mongock/runner/core/changelogs/withConstructor/ChangeUnitWithValidConstructor.java
+++ b/mongock-core/mongock-runner/mongock-runner-core/src/test/java/io/mongock/runner/core/changelogs/withConstructor/ChangeUnitWithValidConstructor.java
@@ -1,0 +1,20 @@
+package io.mongock.runner.core.changelogs.withConstructor;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+
+@ChangeUnit(id = "ChangeUnitWithValidConstructor", order = "1")
+public class ChangeUnitWithValidConstructor {
+
+  public ChangeUnitWithValidConstructor() {
+  }
+
+  @Execution
+  public void execution() {
+  }
+
+  @RollbackExecution
+  public void rollbackExecution() {
+  }
+}

--- a/mongock-core/mongock-runner/mongock-runner-core/src/test/java/io/mongock/runner/core/changelogs/withConstructor/ChangeUnitWithValidConstructorsHavingChangeUnitConstructor.java
+++ b/mongock-core/mongock-runner/mongock-runner-core/src/test/java/io/mongock/runner/core/changelogs/withConstructor/ChangeUnitWithValidConstructorsHavingChangeUnitConstructor.java
@@ -1,0 +1,35 @@
+package io.mongock.runner.core.changelogs.withConstructor;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.ChangeUnitConstructor;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+
+@ChangeUnit(id = "ChangeUnitWithValidConstructorsHavingChangeUnitConstructor", order = "1")
+public class ChangeUnitWithValidConstructorsHavingChangeUnitConstructor {
+
+  public static final String DUMMY_VALUE = "dummyValue";
+  private final String dummy;
+
+  public ChangeUnitWithValidConstructorsHavingChangeUnitConstructor(String dummy) {
+    this.dummy = dummy;
+  }
+
+
+  @ChangeUnitConstructor
+  public ChangeUnitWithValidConstructorsHavingChangeUnitConstructor() {
+    this.dummy = DUMMY_VALUE;
+  }
+
+  @Execution
+  public void execution() {
+  }
+
+  @RollbackExecution
+  public void rollbackExecution() {
+  }
+
+  public String getDummy() {
+    return dummy;
+  }
+}

--- a/mongock-core/mongock-runner/mongock-runner-core/src/test/java/io/mongock/runner/core/changelogs/withConstructor/ChangeUnitWithoutValidConstructor.java
+++ b/mongock-core/mongock-runner/mongock-runner-core/src/test/java/io/mongock/runner/core/changelogs/withConstructor/ChangeUnitWithoutValidConstructor.java
@@ -1,0 +1,20 @@
+package io.mongock.runner.core.changelogs.withConstructor;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+
+@ChangeUnit(id = "ChangeUnitWithoutValidConstructor", order = "1")
+public class ChangeUnitWithoutValidConstructor {
+
+  private ChangeUnitWithoutValidConstructor() {
+  }
+
+  @Execution
+  public void execution() {
+  }
+
+  @RollbackExecution
+  public void rollbackExecution() {
+  }
+}

--- a/mongock-core/mongock-runner/mongock-runner-core/src/test/java/io/mongock/runner/core/executor/ChangeUnitExecutorImplTest.java
+++ b/mongock-core/mongock-runner/mongock-runner-core/src/test/java/io/mongock/runner/core/executor/ChangeUnitExecutorImplTest.java
@@ -26,6 +26,7 @@ import io.mongock.runner.core.changelogs.skipmigration.runalways.ChangeLogAlread
 import io.mongock.runner.core.changelogs.skipmigration.withnochangeset.ChangeLogWithNoChangeSet;
 import io.mongock.runner.core.changelogs.system.NewChangeUnit;
 import io.mongock.runner.core.changelogs.system.SystemChangeUnit;
+import io.mongock.runner.core.changelogs.withConstructor.ChangeUnitWithoutValidConstructor;
 import io.mongock.runner.core.changelogs.withRollback.AdvanceChangeLogWithBefore;
 import io.mongock.runner.core.changelogs.withRollback.AdvanceChangeLogWithBeforeAndChangeSetFailing;
 import io.mongock.runner.core.changelogs.withRollback.BasicChangeLogWithExceptionInChangeSetAndRollback;
@@ -63,6 +64,7 @@ import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -962,6 +964,16 @@ public class ChangeUnitExecutorImplTest {
     assertEquals("AdvanceChangeLogWithBeforeAndChangeSetFailing_before", changeEntryList.get(4).getChangeId());
     assertEquals(ChangeState.ROLLED_BACK, changeEntryList.get(4).getState());
 
+  }
+
+  @Test
+  public void shouldNotCreateInstanceWhenNoValidConstructorExist() {
+    ChangeLogRuntimeImpl changeLogRuntime = getChangeLogRuntime(new DependencyManager());
+    MongockException mongockException = assertThrows(MongockException.class,
+        () -> changeLogRuntime.getInstance(ChangeUnitWithoutValidConstructor.class));
+    assertEquals("Mongock cannot find a valid constructor for " +
+        "changeUnit[io.mongock.runner.core.changelogs.withConstructor.ChangeUnitWithoutValidConstructor]",
+        mongockException.getMessage());
   }
 
   private SortedSet<ChangeLogItem> createInitialChangeLogsByPackage(Class<?>... executorChangeLogClass) {

--- a/mongock-core/mongock-runner/mongock-runner-core/src/test/java/io/mongock/runner/core/executor/ChangeUnitExecutorImplTest.java
+++ b/mongock-core/mongock-runner/mongock-runner-core/src/test/java/io/mongock/runner/core/executor/ChangeUnitExecutorImplTest.java
@@ -26,6 +26,7 @@ import io.mongock.runner.core.changelogs.skipmigration.runalways.ChangeLogAlread
 import io.mongock.runner.core.changelogs.skipmigration.withnochangeset.ChangeLogWithNoChangeSet;
 import io.mongock.runner.core.changelogs.system.NewChangeUnit;
 import io.mongock.runner.core.changelogs.system.SystemChangeUnit;
+import io.mongock.runner.core.changelogs.withConstructor.ChangeUnitWithMoreThanOneChangeUnitConstructor;
 import io.mongock.runner.core.changelogs.withConstructor.ChangeUnitWithoutValidConstructor;
 import io.mongock.runner.core.changelogs.withRollback.AdvanceChangeLogWithBefore;
 import io.mongock.runner.core.changelogs.withRollback.AdvanceChangeLogWithBeforeAndChangeSetFailing;
@@ -973,6 +974,18 @@ public class ChangeUnitExecutorImplTest {
         () -> changeLogRuntime.getInstance(ChangeUnitWithoutValidConstructor.class));
     assertEquals("Mongock cannot find a valid constructor for " +
         "changeUnit[io.mongock.runner.core.changelogs.withConstructor.ChangeUnitWithoutValidConstructor]",
+        mongockException.getMessage());
+  }
+
+  @Test
+  public void shouldNotCreateInstanceWhenMoreThanOneConstructorIsAnnotatedWithChangeUnitConstructor() {
+    ChangeLogRuntimeImpl changeLogRuntime = getChangeLogRuntime(new DependencyManager());
+    MongockException mongockException = assertThrows(MongockException.class,
+        () -> changeLogRuntime.getInstance(ChangeUnitWithMoreThanOneChangeUnitConstructor.class));
+    assertEquals("Found multiple constructors for" +
+            " changeUnit[io.mongock.runner.core.changelogs.withConstructor.ChangeUnitWithMoreThanOneChangeUnitConstructor] " +
+            "without annotation @ChangeUnitConstructor. " +
+            "Annotate the one you want Mongock to use to instantiate your changeUnit",
         mongockException.getMessage());
   }
 

--- a/mongock-core/mongock-runner/mongock-runner-core/src/test/java/io/mongock/runner/core/executor/ChangeUnitExecutorImplTest.java
+++ b/mongock-core/mongock-runner/mongock-runner-core/src/test/java/io/mongock/runner/core/executor/ChangeUnitExecutorImplTest.java
@@ -26,7 +26,10 @@ import io.mongock.runner.core.changelogs.skipmigration.runalways.ChangeLogAlread
 import io.mongock.runner.core.changelogs.skipmigration.withnochangeset.ChangeLogWithNoChangeSet;
 import io.mongock.runner.core.changelogs.system.NewChangeUnit;
 import io.mongock.runner.core.changelogs.system.SystemChangeUnit;
+import io.mongock.runner.core.changelogs.withConstructor.ChangeUnitWithDefaultConstructor;
 import io.mongock.runner.core.changelogs.withConstructor.ChangeUnitWithMoreThanOneChangeUnitConstructor;
+import io.mongock.runner.core.changelogs.withConstructor.ChangeUnitWithValidConstructor;
+import io.mongock.runner.core.changelogs.withConstructor.ChangeUnitWithValidConstructorsHavingChangeUnitConstructor;
 import io.mongock.runner.core.changelogs.withConstructor.ChangeUnitWithoutValidConstructor;
 import io.mongock.runner.core.changelogs.withRollback.AdvanceChangeLogWithBefore;
 import io.mongock.runner.core.changelogs.withRollback.AdvanceChangeLogWithBeforeAndChangeSetFailing;
@@ -65,6 +68,7 @@ import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doThrow;
@@ -987,6 +991,28 @@ public class ChangeUnitExecutorImplTest {
             "without annotation @ChangeUnitConstructor. " +
             "Annotate the one you want Mongock to use to instantiate your changeUnit",
         mongockException.getMessage());
+  }
+
+  @Test
+  public void shouldCreateInstanceWhenOnlyOneValidConstructorExistWithoutChangeUnitConstructor() {
+    ChangeLogRuntimeImpl changeLogRuntime = getChangeLogRuntime(new DependencyManager());
+    assertNotNull(changeLogRuntime.getInstance(ChangeUnitWithValidConstructor.class));
+  }
+
+  @Test
+  public void shouldCreateInstanceWithDefaultConstructor() {
+    ChangeLogRuntimeImpl changeLogRuntime = getChangeLogRuntime(new DependencyManager());
+    assertNotNull(changeLogRuntime.getInstance(ChangeUnitWithDefaultConstructor.class));
+  }
+
+  @Test
+  public void shouldCreateInstanceWhenOneValidConstructorExistWithChangeUnitConstructor() {
+    ChangeLogRuntimeImpl changeLogRuntime = getChangeLogRuntime(new DependencyManager());
+    ChangeUnitWithValidConstructorsHavingChangeUnitConstructor instance =
+        (ChangeUnitWithValidConstructorsHavingChangeUnitConstructor) changeLogRuntime
+            .getInstance(ChangeUnitWithValidConstructorsHavingChangeUnitConstructor.class);
+    assertNotNull(instance);
+    assertEquals(ChangeUnitWithValidConstructorsHavingChangeUnitConstructor.DUMMY_VALUE, instance.getDummy());
   }
 
   private SortedSet<ChangeLogItem> createInitialChangeLogsByPackage(Class<?>... executorChangeLogClass) {


### PR DESCRIPTION
## Issue reference

[508](https://github.com/mongock/mongock/issues/508)

## Documentation PR reference

[38](https://github.com/mongock/mongock-docs/pull/38)

## Description and context

Used Optionals and Stream for null safe iterations

## Benefits

[What benefits will be realized by the code change?]

Improve existing exceptions, add ability to specify which constructor to inject dependencies to.

## Possible Drawbacks

[What are the possible side-effects or negative impacts of the code change?]

None I can think of.

## Checklist 
- [x] Unit tests provided
- [ ] Integration tests provided 
- [x] Documentation updated in [documentation project](https://github.com/mongock/mongock-docs)
- [ ] Updated example in [example projects](https://github.com/mongock/mongock-examples) // can't find use of constructor there

