### PR TITLE
added internal jdk packages(java, com.sun, javax, jdk, sun) to the de…

### DIFF
--- a/mongock-core/mongock-driver/mongock-driver-api/src/main/java/io/mongock/driver/api/lock/guard/proxy/LockGuardProxyFactory.java
+++ b/mongock-core/mongock-driver/mongock-driver-api/src/main/java/io/mongock/driver/api/lock/guard/proxy/LockGuardProxyFactory.java
@@ -34,7 +34,6 @@ public class LockGuardProxyFactory {
     };
   }
 
-  private final static List<String> javaPackagePrefixes = Collections.emptyList();//Arrays.asList("java.", "com.sun.", "javax.", "jdk.", "sun.");
   private final LockManager lockManager;
   private final Collection<String> notProxiedPackagePrefixes;
   private final Set<String> nonGuardedMethods;
@@ -49,8 +48,7 @@ public class LockGuardProxyFactory {
 
   public LockGuardProxyFactory(LockManager lockManager, Collection<String> notProxiedPackagePrefixes, Set<String> nonGuardedMethods) {
     this.lockManager = lockManager;
-    this.notProxiedPackagePrefixes = new ArrayList<>(notProxiedPackagePrefixes);
-    this.notProxiedPackagePrefixes.addAll(javaPackagePrefixes);
+    this.notProxiedPackagePrefixes = notProxiedPackagePrefixes;
     this.nonGuardedMethods = nonGuardedMethods;
   }
 

--- a/mongock-core/mongock-driver/mongock-driver-api/src/main/java/io/mongock/driver/api/lock/guard/proxy/LockGuardProxyFactory.java
+++ b/mongock-core/mongock-driver/mongock-driver-api/src/main/java/io/mongock/driver/api/lock/guard/proxy/LockGuardProxyFactory.java
@@ -3,7 +3,7 @@ package io.mongock.driver.api.lock.guard.proxy;
 import io.changock.migration.api.annotations.NonLockGuarded;
 import io.mongock.driver.api.lock.LockManager;
 import io.mongock.utils.Constants;
-import io.mongock.utils.Utils;
+import io.mongock.utils.JdkUtil;
 import javassist.util.proxy.ProxyFactory;
 import org.objenesis.ObjenesisStd;
 
@@ -34,7 +34,7 @@ public class LockGuardProxyFactory {
     };
   }
 
-  private final static List<String> javaPackagePrefixes = Collections.emptyList();//Arrays.asList("java.", "com.sun.", "javax.", "jdk.internal.", "sun.");
+  private final static List<String> javaPackagePrefixes = Collections.emptyList();//Arrays.asList("java.", "com.sun.", "javax.", "jdk.", "sun.");
   private final LockManager lockManager;
   private final Collection<String> notProxiedPackagePrefixes;
   private final Set<String> nonGuardedMethods;
@@ -71,8 +71,8 @@ public class LockGuardProxyFactory {
         && isPackageProxiable(interfaceType.getPackage().getName())
         && !interfaceType.isAnnotationPresent(NonLockGuarded.class)
         && !targetObject.getClass().isAnnotationPresent(NonLockGuarded.class)
-        && !Utils.isBasicTypeJDK(targetObject.getClass())
-        && !Utils.isBasicTypeJDK(interfaceType);
+        && !JdkUtil.isInternalJdkClass(targetObject.getClass())
+        && !JdkUtil.isInternalJdkClass(interfaceType);
   }
 
   private boolean isPackageProxiable(String packageName) {

--- a/mongock-core/mongock-driver/mongock-driver-api/src/test/java/io/mongock/driver/api/lock/guard/proxy/LockGuardProxyFactoryTest.java
+++ b/mongock-core/mongock-driver/mongock-driver-api/src/test/java/io/mongock/driver/api/lock/guard/proxy/LockGuardProxyFactoryTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mockito;
 
 import java.io.Serializable;
 import java.net.ContentHandlerFactory;
+import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -40,8 +41,22 @@ public class LockGuardProxyFactoryTest {
   }
 
   @Test
-  public void shouldNotReturnProxy_IfInterfaceTypePackageIsJava() {
+  public void shouldNotReturnProxy_IfIsJDKStructure() {
     assertFalse(ReflectionUtils.isProxy(getRawProxy(new ArrayList<>(), List.class)));
+  }
+
+  @Test
+  public void shouldNotReturnProxy_IfIsJDKBasicType() {
+    assertFalse(ReflectionUtils.isProxy(getRawProxy("Value", String.class)));
+  }
+
+  @Test
+  public void shouldNotReturnProxy_IfIsJDKInternal() {
+    assertFalse(ReflectionUtils.isProxy(getRawProxy(new ProtectionDomain(null, null), ProtectionDomain.class)));
+  }
+
+  @Test
+  public void shouldNotReturnProxy_IfIsWellKnownClassesNonProxiable() {
     assertFalse(ReflectionUtils.isProxy(getRawProxy(new ContentHandlerFactoryImpl(), ContentHandlerFactory.class)));
   }
 

--- a/mongock-core/mongock-utils/src/main/java/io/mongock/utils/JdkUtil.java
+++ b/mongock-core/mongock-utils/src/main/java/io/mongock/utils/JdkUtil.java
@@ -1,22 +1,28 @@
 package io.mongock.utils;
 
 import java.net.ContentHandlerFactory;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
-public final class Utils {
+public final class JdkUtil {
 
-  private Utils() {
+  private JdkUtil() {
   }
 
-  public static boolean isBasicTypeJDK(Class<?> clazz) {
+  private static final List<String> jdkInternalPackages = Arrays.asList("java.", "com.sun.", "javax.", "jdk.", "sun.");
+
+  public static boolean isInternalJdkClass(Class<?> clazz) {
     return clazz.isPrimitive()
-        || String.class.equals(clazz)
-        || Class.class.equals(clazz)
-        || isJDKWrapper(clazz)
-        || isJDKDataStructure(clazz)
+        || isJdkNativeType(clazz)
+        || isJdkDataStructure(clazz)
+        || isInternalJdkPackage(clazz)
         || isOtherWellKnownClassesNonProxiable(clazz);
+  }
 
-
+  private static boolean isInternalJdkPackage(Class<?> clazz) {
+    String packageName = clazz.getPackage().getName();
+    return jdkInternalPackages.stream().anyMatch(packageName::startsWith);
   }
 
   //should be added all the extra classes that shouldn't be proxiable
@@ -24,8 +30,10 @@ public final class Utils {
     return ContentHandlerFactory.class.isAssignableFrom(clazz);
   }
 
-  private static boolean isJDKWrapper(Class<?> clazz) {
+  private static boolean isJdkNativeType(Class<?> clazz) {
     return Boolean.class.equals(clazz)
+        || String.class.equals(clazz)
+        || Class.class.equals(clazz)
         || Character.class.equals(clazz)
         || Byte.class.equals(clazz)
         || Short.class.equals(clazz)
@@ -36,7 +44,7 @@ public final class Utils {
         || Void.class.equals(clazz);
   }
 
-  private static boolean isJDKDataStructure(Class<?> clazz) {
+  private static boolean isJdkDataStructure(Class<?> clazz) {
     return Iterable.class.isAssignableFrom(clazz)
         || Map.class.isAssignableFrom(clazz);
     //should be added all the JDK data structure that shouldn't be proxied


### PR DESCRIPTION
Change to prevent Mongock to proxy internal JDK classes. This was done, but somehow was commented temporally and it was never restored.

Now we have extend the test to reduce the chances of this happening again