### PR TITLE
Fix retrieving executionInMillis saved as Integer by Mongo driver

### DIFF
--- a/drivers/mongodb/mongodb-driver-test-template/src/main/java/io/mongock/driver/mongodb/test/template/MongoChangeEntryRepositoryITestBase.java
+++ b/drivers/mongodb/mongodb-driver-test-template/src/main/java/io/mongock/driver/mongodb/test/template/MongoChangeEntryRepositoryITestBase.java
@@ -2,6 +2,7 @@ package io.mongock.driver.mongodb.test.template;
 
 import com.mongodb.client.model.IndexOptions;
 import io.mongock.api.exception.MongockException;
+import io.mongock.driver.api.entry.ChangeEntry;
 import io.mongock.driver.api.entry.ChangeEntryService;
 import io.mongock.driver.mongodb.test.template.util.IntegrationTestBase;
 import org.bson.Document;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.Date;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -33,15 +35,23 @@ public abstract class MongoChangeEntryRepositoryITestBase extends IntegrationTes
     initializeRepository(false);
   }
 
-
-
-  private void createAndInsertChangeEntry(boolean withState, String state, String changeId, String author, String executionId) {
+  @Test
+  public void getEntriesLog_WorksRegardlessOfExecutionMillisMissingIntegerOrLong() throws MongockException {
     initializeRepository(true);
+    createAndInsertChangeEntry(false, null, "changeId1", "author", "executionId1", Long.MAX_VALUE);
+    createAndInsertChangeEntry(false, null, "changeId2", "author", "executionId2", Integer.MAX_VALUE);
+    createAndInsertChangeEntry(false, null, "changeId3", "author", "executionId3", null);
+    List<ChangeEntry> result = repository.getEntriesLog();
+    assertEquals(3, result.size());
+  }
+
+  private void createAndInsertChangeEntry(boolean withState, String state, String changeId, String author, String executionId, Number executionMillis) {
     Document existingEntry = new Document()
         .append("executionId", executionId)
         .append("changeId", changeId)
         .append("author", author)
         .append("timestamp", Date.from(Instant.now()))
+        .append("executionMillis", executionMillis)
         .append("changeLogClass", "anyClass")
         .append("changeSetMethod", "anyMethod")
         .append("metadata", null);

--- a/drivers/mongodb/mongodb-reactive-driver/src/main/java/io/mongock/driver/mongodb/reactive/repository/MongoReactiveChangeEntryRepository.java
+++ b/drivers/mongodb/mongodb-reactive-driver/src/main/java/io/mongock/driver/mongodb/reactive/repository/MongoReactiveChangeEntryRepository.java
@@ -111,7 +111,7 @@ public class MongoReactiveChangeEntryRepository extends MongoReactiveRepositoryB
             entry.containsKey(KEY_TYPE) ? ChangeType.valueOf(entry.getString(KEY_TYPE)) : null,
             entry.getString(KEY_CHANGELOG_CLASS),
             entry.getString(KEY_CHANGESET_METHOD),
-            entry.containsKey(KEY_EXECUTION_MILLIS) ? entry.getLong(KEY_EXECUTION_MILLIS) : -1L,
+            entry.containsKey(KEY_EXECUTION_MILLIS) ? ((Number) entry.get(KEY_EXECUTION_MILLIS)).longValue() : -1L,
             entry.getString(KEY_EXECUTION_HOSTNAME),
             entry.get(KEY_METADATA)))
         .collect(Collectors.toList());

--- a/drivers/mongodb/mongodb-sync-v4-driver/src/main/java/io/mongock/driver/mongodb/sync/v4/repository/MongoSync4ChangeEntryRepository.java
+++ b/drivers/mongodb/mongodb-sync-v4-driver/src/main/java/io/mongock/driver/mongodb/sync/v4/repository/MongoSync4ChangeEntryRepository.java
@@ -114,7 +114,7 @@ public class MongoSync4ChangeEntryRepository extends MongoSync4RepositoryBase<Ch
             entry.containsKey(KEY_TYPE) ? ChangeType.valueOf(entry.getString(KEY_TYPE)) : null,
             entry.getString(KEY_CHANGELOG_CLASS),
             entry.getString(KEY_CHANGESET_METHOD),
-            entry.containsKey(KEY_EXECUTION_MILLIS) ? entry.getLong(KEY_EXECUTION_MILLIS) : -1L,
+            entry.containsKey(KEY_EXECUTION_MILLIS) ? ((Number) entry.get(KEY_EXECUTION_MILLIS)).longValue() : -1L,
             entry.getString(KEY_EXECUTION_HOSTNAME),
             entry.get(KEY_METADATA)))
         .collect(Collectors.toList());

--- a/drivers/mongodb/mongodb-v3-driver/src/main/java/io/mongock/driver/mongodb/v3/repository/Mongo3ChangeEntryRepository.java
+++ b/drivers/mongodb/mongodb-v3-driver/src/main/java/io/mongock/driver/mongodb/v3/repository/Mongo3ChangeEntryRepository.java
@@ -111,7 +111,7 @@ public class Mongo3ChangeEntryRepository extends Mongo3RepositoryBase<ChangeEntr
             entry.containsKey(KEY_TYPE) ? ChangeType.valueOf(entry.getString(KEY_TYPE)) : null,
             entry.getString(KEY_CHANGELOG_CLASS),
             entry.getString(KEY_CHANGESET_METHOD),
-            entry.containsKey(KEY_EXECUTION_MILLIS) ? entry.getLong(KEY_EXECUTION_MILLIS) : -1L,
+            entry.containsKey(KEY_EXECUTION_MILLIS) ? ((Number) entry.get(KEY_EXECUTION_MILLIS)).longValue() : -1L,
             entry.getString(KEY_EXECUTION_HOSTNAME),
             entry.get(KEY_METADATA)))
         .collect(Collectors.toList());


### PR DESCRIPTION
… MongoDB

## Issue reference

Closes flamingock/mongock#127

## Documentation PR reference

No documentation changes

## Description and context

The mongo driver may have saved the exectutionMillis field as Integer instead of Long for legacy migrations. This changes allows the Mongock migration to run regardless if the field is saved as Long or Integer.

## Benefits

MongoCk will run old migration scripts more reliably.

## Possible Drawbacks

I don't see any drawbacks.

## Checklist 
- [ ] Unit tests provided
- [ ] Integration tests provided 
- [ ] Documentation updated in [documentation project](https://github.com/mongock/mongock-docs)
- [ ] Updated example in [example projects](https://github.com/mongock/mongock-examples)

