### PR TITLE
If there are no dynamo write transactions, return instead of attempting the dynamo call

### DIFF
--- a/drivers/dynamodb/dynamodb-driver/src/main/kotlin/io/mongock/driver/dynamodb/driver/DynamoDBDriverBase.kt
+++ b/drivers/dynamodb/dynamodb-driver/src/main/kotlin/io/mongock/driver/dynamodb/driver/DynamoDBDriverBase.kt
@@ -98,6 +98,7 @@ abstract class DynamoDBDriverBase protected constructor(
             operation.run()
             if (!transactionItems!!.containsUserTransactions()) {
                 logger.debug { "no transaction items for changeUnit" }
+                return
             }
             val result = client.transactWriteItems(
                 TransactWriteItemsRequest()

--- a/drivers/dynamodb/dynamodb-driver/src/test/kotlin/io/mongock/driver/dynamodb/driver/DynamoDBDriverITest.kt
+++ b/drivers/dynamodb/dynamodb-driver/src/test/kotlin/io/mongock/driver/dynamodb/driver/DynamoDBDriverITest.kt
@@ -70,6 +70,16 @@ class DynamoDBDriverITest : DescribeSpec({
                 listAdded.forEach { companion.isInserted(driver.getMigrationRepositoryNameForTest(), it) shouldBe true }
 
             }
+            When("sending no transactions") {
+                should("not fail") {
+                    val driver = companion.getDriver()
+                    driver.setMigrationRepositoryName("driver-transaction-no-transactions")
+                    driver.initialize()
+                    driver.prepareForExecutionBlock()
+                    driver.transactioner.get().executeInTransaction {
+                    }
+                }
+            }
         }
     } else {
         context(">>TRANSACTION TESTS DISABLED") {

--- a/drivers/dynamodb/dynamodb-driver/src/test/kotlin/io/mongock/driver/dynamodb/driver/DynamoDBDriverITest.kt
+++ b/drivers/dynamodb/dynamodb-driver/src/test/kotlin/io/mongock/driver/dynamodb/driver/DynamoDBDriverITest.kt
@@ -70,16 +70,6 @@ class DynamoDBDriverITest : DescribeSpec({
                 listAdded.forEach { companion.isInserted(driver.getMigrationRepositoryNameForTest(), it) shouldBe true }
 
             }
-            When("sending no transactions") {
-                should("not fail") {
-                    val driver = companion.getDriver()
-                    driver.setMigrationRepositoryName("driver-transaction-no-transactions")
-                    driver.initialize()
-                    driver.prepareForExecutionBlock()
-                    driver.transactioner.get().executeInTransaction {
-                    }
-                }
-            }
         }
     } else {
         context(">>TRANSACTION TESTS DISABLED") {


### PR DESCRIPTION
## Issue reference

If there are no dynamo writeTransactions added in the migration, return instead of attempting to send those to dynamo.  This prevents a 400 error.

This problem is blocking our ability to start using Mongock for our database migration tool in spring boot. 

[Reference or link to the issue covered in the PR](https://github.com/mongock/mongock/issues/573)

## Documentation PR reference

I don't think this requires any documentation changes.
[Reference or link to the Pull request on the documentation project, performing the required update reflecting your change]
[Documentation project](https://github.com/mongock/mongock-docs)

## Description and context

My migration script iterates through the @DynamoDbTable classes in our spring project and for each it checks if that table exists.  If the table does not exist, the table is created.  This results in 0 WriteTransactions added in the execution.

As a result mongock fails - it tries to make a request to dynamo with a list of 0 WriteTransactions and dynamo returns a 400, causing mongock to fail and the spring boot service to not start.  

Instead of attempting to make the dynamo transactWriteItems call with no writeTransactions, just return.

## Benefits

For my case, mongock will no longer fail and prevent the service from starting.  

## Possible Drawbacks

I cannot think of any.

## Checklist 
- [] Unit tests provided
- [] Integration tests provided 
- [N/A] Documentation updated in [documentation project](https://github.com/mongock/mongock-docs)
- [N/A] Updated example in [example projects](https://github.com/mongock/mongock-examples)

NOTE: I could not reproduce this in unit tests, so apparently this does not happen with the test dynamoDb client.  There does not seem to be any integration tests for dynamoDb and I am not a great kotlin developer.  If you could get me started by adding an integ test structure I could go from there?
