### PR TITLE
fix: defaultMigrationAuthor not set from spring configuration

### DIFF
--- a/mongock-core/mongock-api/src/main/java/io/mongock/api/config/MongockConfiguration.java
+++ b/mongock-core/mongock-api/src/main/java/io/mongock/api/config/MongockConfiguration.java
@@ -170,6 +170,7 @@ public class MongockConfiguration implements ExecutorConfiguration {
     transactionStrategy = from.getTransactionStrategy();
     maxTries = from.getMaxTries();
     maxWaitingForLockMillis = from.getMaxWaitingForLockMillis();
+    defaultMigrationAuthor = from.getDefaultMigrationAuthor();
   }
 
   public long getLockAcquiredForMillis() {

--- a/mongock-core/mongock-api/src/test/java/io/mongock/api/config/MongockConfigurationTest.java
+++ b/mongock-core/mongock-api/src/test/java/io/mongock/api/config/MongockConfigurationTest.java
@@ -9,6 +9,32 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class MongockConfigurationTest {
 
   @Test
+  public void shouldCopyDefaultMigrationAuthorFromExisitingConfigurationDefault() {
+    MongockConfiguration conf = new MongockConfiguration();
+
+    MongockConfiguration newConf = new MongockConfiguration();
+    newConf.updateFrom(conf);
+    assertEquals(MongockConfiguration.DEFAULT_MIGRATION_AUTHOR, newConf.getDefaultMigrationAuthor());
+  }
+
+  @Test
+  public void shouldCopyDefaultMigrationAuthorFromExisitingConfigurationIfSet() {
+    MongockConfiguration conf = new MongockConfiguration();
+    conf.setDefaultMigrationAuthor("joey ramone");
+
+    MongockConfiguration newConf = new MongockConfiguration();
+    newConf.updateFrom(conf);
+    assertEquals("joey ramone", newConf.getDefaultMigrationAuthor());
+  }
+
+  @Test
+  public void shouldReturnNewDefaultMigrationAuthor_IfNewProperty() {
+    MongockConfiguration conf = new MongockConfiguration();
+    conf.setDefaultMigrationAuthor("joey ramone");
+    assertEquals("joey ramone", conf.getDefaultMigrationAuthor());
+  }
+
+  @Test
   public void shouldReturnNewQuitTryingAfterMillis_IfNewProperty() {
     MongockConfiguration conf = new MongockConfiguration();
     conf.setLockQuitTryingAfterMillis(1000L);


### PR DESCRIPTION
## Issue reference

flamingock/mongock#100

[Reference or link to the issue covered in the PR]

## Documentation PR reference

[Reference or link to the Pull request on the documentation project, performing the required update reflecting your change]
[Documentation project](https://github.com/mongock/mongock-docs)

## Description and context

[The code should be self explanatory. However this should help us to understand what your code does, any specific pattern or design used, etc.]

## Benefits

[What benefits will be realized by the code change?]

## Possible Drawbacks

[What are the possible side-effects or negative impacts of the code change?]

## Checklist 
- [ ] Unit tests provided
- [ ] Integration tests provided 
- [ ] Documentation updated in [documentation project](https://github.com/mongock/mongock-docs)
- [ ] Updated example in [example projects](https://github.com/mongock/mongock-examples)

