### PR TITLE
Support Scope and Collections with Special Chars for Cocuhbase Driver

### DIFF
--- a/drivers/couchbase/couchbase-driver/src/main/java/io/mongock/driver/couchbase/util/N1QLQueryProvider.java
+++ b/drivers/couchbase/couchbase-driver/src/main/java/io/mongock/driver/couchbase/util/N1QLQueryProvider.java
@@ -11,9 +11,9 @@ import io.mongock.driver.couchbase.repository.CouchbaseRepositoryBase;
 public final class N1QLQueryProvider {
 
   private final static String SELECT_ALL_CHANGES_DEFAULT = "SELECT `%s`.* FROM `%s` WHERE %s = $type";
-  private final static String SELECT_ALL_CHANGES_CUSTOM = "SELECT %s.* FROM `%s`.%s.%s WHERE %s = $type";
+  private final static String SELECT_ALL_CHANGES_CUSTOM = "SELECT `%s`.* FROM `%s`.`%s`.`%s` WHERE %s = $type";
   private final static String DELETE_ALL_CHANGES_DEFAULT = "DELETE FROM `%s`";
-  private final static String DELETE_ALL_CHANGES_CUSTOM = "DELETE FROM `%s`.%s.%s";
+  private final static String DELETE_ALL_CHANGES_CUSTOM = "DELETE FROM `%s`.`%s`.`%s`";
   private  N1QLQueryProvider(){
     // nothing to do
   }

--- a/drivers/couchbase/couchbase-driver/src/test/java/io/mongock/driver/couchbase/TestcontainersCouchbaseRunner.java
+++ b/drivers/couchbase/couchbase-driver/src/test/java/io/mongock/driver/couchbase/TestcontainersCouchbaseRunner.java
@@ -14,19 +14,26 @@ import java.time.Duration;
 public abstract class TestcontainersCouchbaseRunner {
     private static final String COUCHBASE_CUSTOM_SCOPE = "mongock";
     private static final String COUCHBASE_CUSTOM_COLLECTION = "mongock";
+    private static final String COUCHBASE_CUSTOM_SCOPE_WITH_SPECIAL = "mongock-special";
+    private static final String COUCHBASE_CUSTOM_COLLECTION_WITH_SPECIAL = "mongock-special";
     protected static final String BUCKET_NAME = "mongock";
+    protected static final String BUCKET_NAME_SPECIAL = "mongock-special";
     protected static final String COUCHBASE_USERNAME = "username";
     protected static final String COUCHBASE_PASSWORD = "password";
     protected static final BucketDefinition BUCKET_DEFINITION = new BucketDefinition(BUCKET_NAME);
+    protected static final BucketDefinition BUCKET_DEFINITION_SPECIAL = new BucketDefinition(BUCKET_NAME_SPECIAL);
     private static Cluster CLUSTER_V7;
     private static Collection COLLECTION_V7;
+    private static Collection COLLECTION_V7_WITH_SPECIAL;
     private static Bucket BUCKET_V7;
+    private static Bucket BUCKET_V7_SPECIAL;
     private static Cluster CLUSTER_V6;
     private static Bucket BUCKET_V6;
     private static Collection COLLECTION_V6;
 
     private static final CouchbaseContainer COUCHBASE_CONTAINER_V7 = new CouchbaseContainer("couchbase/server:community-7.1.1")
             .withBucket(BUCKET_DEFINITION)
+            .withBucket(BUCKET_DEFINITION_SPECIAL)
             .withCredentials(COUCHBASE_USERNAME, COUCHBASE_PASSWORD)
             .withStartupTimeout(Duration.ofSeconds(90))
             .waitingFor(Wait.forHealthcheck());
@@ -39,10 +46,12 @@ public abstract class TestcontainersCouchbaseRunner {
 
     static {
         COUCHBASE_CONTAINER_V7.withStartupAttempts(3).start();
-        Cluster cluster = Cluster.connect(COUCHBASE_CONTAINER_V7.getConnectionString(), ClusterOptions.clusterOptions(COUCHBASE_USERNAME, COUCHBASE_PASSWORD));
-        cluster.bucket(BUCKET_NAME).collections().createScope(COUCHBASE_CUSTOM_SCOPE);
-        cluster.bucket(BUCKET_NAME).collections().createCollection(CollectionSpec.create(COUCHBASE_CUSTOM_COLLECTION, COUCHBASE_CUSTOM_SCOPE));
-        cluster.disconnect();
+        try(Cluster cluster = Cluster.connect(COUCHBASE_CONTAINER_V7.getConnectionString(), ClusterOptions.clusterOptions(COUCHBASE_USERNAME, COUCHBASE_PASSWORD))){
+          cluster.bucket(BUCKET_NAME).collections().createScope(COUCHBASE_CUSTOM_SCOPE);
+          cluster.bucket(BUCKET_NAME).collections().createCollection(COUCHBASE_CUSTOM_SCOPE, COUCHBASE_CUSTOM_COLLECTION);
+          cluster.bucket(BUCKET_NAME_SPECIAL).collections().createScope(COUCHBASE_CUSTOM_SCOPE_WITH_SPECIAL);
+          cluster.bucket(BUCKET_NAME_SPECIAL).collections().createCollection(COUCHBASE_CUSTOM_SCOPE_WITH_SPECIAL, COUCHBASE_CUSTOM_COLLECTION_WITH_SPECIAL);  
+        }
         COUCHBASE_CONTAINER_V6.withStartupAttempts(3).start();
     }
 
@@ -64,6 +73,15 @@ public abstract class TestcontainersCouchbaseRunner {
                     .collection(COUCHBASE_CUSTOM_COLLECTION);
         }
         return COLLECTION_V7;
+    }
+
+    public static Collection getCollectionSpecialV7() {
+        if (COLLECTION_V7_WITH_SPECIAL == null) {
+            COLLECTION_V7_WITH_SPECIAL = getBucketV7Special()
+              .scope(COUCHBASE_CUSTOM_SCOPE_WITH_SPECIAL)
+              .collection(COUCHBASE_CUSTOM_COLLECTION_WITH_SPECIAL);
+        }
+        return COLLECTION_V7_WITH_SPECIAL;
     }
 
     public static Cluster getCluster6() {
@@ -99,6 +117,14 @@ public abstract class TestcontainersCouchbaseRunner {
                     .bucket(BUCKET_NAME);
         }
         return BUCKET_V7;
+    }
+
+    public static Bucket getBucketV7Special() {
+        if (BUCKET_V7_SPECIAL == null) {
+           BUCKET_V7_SPECIAL = getCluster7()
+                .bucket(BUCKET_NAME_SPECIAL);
+        }
+        return BUCKET_V7_SPECIAL;
     }
 
 }

--- a/drivers/couchbase/couchbase-driver/src/test/java/io/mongock/driver/couchbase/repository/CouchbaseChangeEntryRepositoryTest.java
+++ b/drivers/couchbase/couchbase-driver/src/test/java/io/mongock/driver/couchbase/repository/CouchbaseChangeEntryRepositoryTest.java
@@ -22,12 +22,14 @@ class CouchbaseChangeEntryRepositoryTest {
     void cleanUp() {
         new CouchbaseChangeEntryRepository(TestcontainersCouchbaseRunner.getCluster6(), TestcontainersCouchbaseRunner.getCollectionV6()).deleteAll();
         new CouchbaseChangeEntryRepository(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7()).deleteAll();
+        new CouchbaseChangeEntryRepository(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionSpecialV7()).deleteAll();
     }
 
     @BeforeAll
     static void initialize() {
         new CouchbaseLockRepository(TestcontainersCouchbaseRunner.getCluster6(), TestcontainersCouchbaseRunner.getCollectionV6()).initialize();
         new CouchbaseLockRepository(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7()).initialize();
+        new CouchbaseLockRepository(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionSpecialV7()).initialize();
     }
 
     @ParameterizedTest

--- a/drivers/couchbase/couchbase-driver/src/test/java/io/mongock/driver/couchbase/repository/CouchbaseLockRepositoryTest.java
+++ b/drivers/couchbase/couchbase-driver/src/test/java/io/mongock/driver/couchbase/repository/CouchbaseLockRepositoryTest.java
@@ -26,11 +26,15 @@ class CouchbaseLockRepositoryTest {
     void cleanUp() {
         new CouchbaseLockRepository(TestcontainersCouchbaseRunner.getCluster6(), TestcontainersCouchbaseRunner.getCollectionV6()).deleteAll();
         new CouchbaseLockRepository(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7()).deleteAll();
+        new CouchbaseLockRepository(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionSpecialV7()).deleteAll();
         if (TestcontainersCouchbaseRunner.getCollectionV6().exists(lockEntryKeyGenerator.toKey(LockEntryProvider.LOCK_KEY)).exists()) {
             TestcontainersCouchbaseRunner.getCollectionV6().remove(lockEntryKeyGenerator.toKey(LockEntryProvider.LOCK_KEY), RemoveOptions.removeOptions().durability(PersistTo.ACTIVE, ReplicateTo.NONE));
         }
         if (TestcontainersCouchbaseRunner.getCollectionV7().exists(lockEntryKeyGenerator.toKey(LockEntryProvider.LOCK_KEY)).exists()) {
             TestcontainersCouchbaseRunner.getCollectionV7().remove(lockEntryKeyGenerator.toKey(LockEntryProvider.LOCK_KEY), RemoveOptions.removeOptions().durability(PersistTo.ACTIVE, ReplicateTo.NONE));
+        }
+        if (TestcontainersCouchbaseRunner.getCollectionSpecialV7().exists(lockEntryKeyGenerator.toKey(LockEntryProvider.LOCK_KEY)).exists()) {
+          TestcontainersCouchbaseRunner.getCollectionSpecialV7().remove(lockEntryKeyGenerator.toKey(LockEntryProvider.LOCK_KEY), RemoveOptions.removeOptions().durability(PersistTo.ACTIVE, ReplicateTo.NONE));
         }
     }
 
@@ -38,6 +42,7 @@ class CouchbaseLockRepositoryTest {
     static void initialize() {
         new CouchbaseLockRepository(TestcontainersCouchbaseRunner.getCluster6(), TestcontainersCouchbaseRunner.getCollectionV6()).initialize();
         new CouchbaseLockRepository(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7()).initialize();
+        new CouchbaseLockRepository(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionSpecialV7()).initialize();
     }
 
     @ParameterizedTest

--- a/drivers/couchbase/couchbase-driver/src/test/java/io/mongock/driver/couchbase/util/ChangeEntryProvider.java
+++ b/drivers/couchbase/couchbase-driver/src/test/java/io/mongock/driver/couchbase/util/ChangeEntryProvider.java
@@ -97,21 +97,27 @@ public class ChangeEntryProvider {
                 Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7(), CHANGE_1),
                 Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7(), CHANGE_2),
                 Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7(), CHANGE_3),
-                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7(), CHANGE_FAILED)
+                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7(), CHANGE_FAILED),
+                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionSpecialV7(), CHANGE_1),
+                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionSpecialV7(), CHANGE_2),
+                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionSpecialV7(), CHANGE_3),
+                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionSpecialV7(), CHANGE_FAILED)
         );
     }
 
     static Stream<Arguments> changesAsList() {
         return Stream.of(
                 Arguments.of(TestcontainersCouchbaseRunner.getCluster6(), TestcontainersCouchbaseRunner.getCollectionV6(), Arrays.asList(CHANGE_1, CHANGE_2, CHANGE_3, CHANGE_FAILED)),
-                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7(), Arrays.asList(CHANGE_1, CHANGE_2, CHANGE_3, CHANGE_FAILED))
+                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7(), Arrays.asList(CHANGE_1, CHANGE_2, CHANGE_3, CHANGE_FAILED)),
+                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionSpecialV7(), Arrays.asList(CHANGE_1, CHANGE_2, CHANGE_3, CHANGE_FAILED))
         );
     }
 
     static Stream<Arguments> change1AndChange1U() {
         return Stream.of(
                 Arguments.of(TestcontainersCouchbaseRunner.getCluster6(), TestcontainersCouchbaseRunner.getCollectionV6(), CHANGE_1, CHANGE_1_U),
-                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7(), CHANGE_1, CHANGE_1_U)
+                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7(), CHANGE_1, CHANGE_1_U),
+                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionSpecialV7(), CHANGE_1, CHANGE_1_U)
         );
     }
 }

--- a/drivers/couchbase/couchbase-driver/src/test/java/io/mongock/driver/couchbase/util/CouchbaseVersionProvider.java
+++ b/drivers/couchbase/couchbase-driver/src/test/java/io/mongock/driver/couchbase/util/CouchbaseVersionProvider.java
@@ -9,14 +9,16 @@ public class CouchbaseVersionProvider {
     static Stream<Arguments> versions() {
         return Stream.of(
                 Arguments.of(TestcontainersCouchbaseRunner.getBucketV6(), "6.6.0"),
-                Arguments.of(TestcontainersCouchbaseRunner.getBucketV7(), "7.1.1")
+                Arguments.of(TestcontainersCouchbaseRunner.getBucketV7(), "7.1.1"),
+                Arguments.of(TestcontainersCouchbaseRunner.getBucketV7Special(), "7.1.1")
         );
     }
 
     static Stream<Arguments> versions2() {
         return Stream.of(
                 Arguments.of(TestcontainersCouchbaseRunner.getBucketV6(), false),
-                Arguments.of(TestcontainersCouchbaseRunner.getBucketV7(), true)
+                Arguments.of(TestcontainersCouchbaseRunner.getBucketV7(), true),
+                Arguments.of(TestcontainersCouchbaseRunner.getBucketV7Special(), true)
         );
     }
 }

--- a/drivers/couchbase/couchbase-driver/src/test/java/io/mongock/driver/couchbase/util/LockEntryProvider.java
+++ b/drivers/couchbase/couchbase-driver/src/test/java/io/mongock/driver/couchbase/util/LockEntryProvider.java
@@ -18,42 +18,48 @@ public class LockEntryProvider {
     public static Stream<Arguments> lockOwner1NotExpired() {
         return Stream.of(
                 Arguments.of(TestcontainersCouchbaseRunner.getCluster6(), TestcontainersCouchbaseRunner.getCollectionV6(), LOCK_OWNER_1_NOT_EXPIRED),
-                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7(), LOCK_OWNER_1_NOT_EXPIRED)
+                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7(), LOCK_OWNER_1_NOT_EXPIRED),
+                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionSpecialV7(), LOCK_OWNER_1_NOT_EXPIRED)
         );
     }
 
     public static Stream<Arguments> lockOwner1NotExpiredAndLockOwner1NotExpiredUpdated() {
         return Stream.of(
                 Arguments.of(TestcontainersCouchbaseRunner.getCluster6(), TestcontainersCouchbaseRunner.getCollectionV6(), LOCK_OWNER_1_NOT_EXPIRED, LOCK_OWNER_1_NOT_EXPIRED_UPDATED),
-                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7(), LOCK_OWNER_1_NOT_EXPIRED, LOCK_OWNER_1_NOT_EXPIRED_UPDATED)
+                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7(), LOCK_OWNER_1_NOT_EXPIRED, LOCK_OWNER_1_NOT_EXPIRED_UPDATED),
+                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionSpecialV7(), LOCK_OWNER_1_NOT_EXPIRED, LOCK_OWNER_1_NOT_EXPIRED_UPDATED)
         );
     }
 
     public static Stream<Arguments> lockOwner1ExpiredAndLockOwner2NotExpired() {
         return Stream.of(
                 Arguments.of(TestcontainersCouchbaseRunner.getCluster6(), TestcontainersCouchbaseRunner.getCollectionV6(), LOCK_OWNER_1_EXPIRED, LOCK_OWNER_2_NOT_EXPIRED),
-                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7(), LOCK_OWNER_1_EXPIRED, LOCK_OWNER_2_NOT_EXPIRED)
+                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7(), LOCK_OWNER_1_EXPIRED, LOCK_OWNER_2_NOT_EXPIRED),
+                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionSpecialV7(), LOCK_OWNER_1_EXPIRED, LOCK_OWNER_2_NOT_EXPIRED)
         );
     }
 
     public static Stream<Arguments> lockOwner1NotExpiredAndLockOwner2NotExpired() {
         return Stream.of(
                 Arguments.of(TestcontainersCouchbaseRunner.getCluster6(), TestcontainersCouchbaseRunner.getCollectionV6(), LOCK_OWNER_1_NOT_EXPIRED, LOCK_OWNER_2_NOT_EXPIRED),
-                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7(), LOCK_OWNER_1_NOT_EXPIRED, LOCK_OWNER_2_NOT_EXPIRED)
+                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7(), LOCK_OWNER_1_NOT_EXPIRED, LOCK_OWNER_2_NOT_EXPIRED),
+                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionSpecialV7(), LOCK_OWNER_1_NOT_EXPIRED, LOCK_OWNER_2_NOT_EXPIRED)
         );
     }
 
     public static Stream<Arguments> lockOwner1ExpiredAndLockOwner1NotExpiredUpdated() {
         return Stream.of(
                 Arguments.of(TestcontainersCouchbaseRunner.getCluster6(), TestcontainersCouchbaseRunner.getCollectionV6(), LOCK_OWNER_1_EXPIRED, LOCK_OWNER_1_NOT_EXPIRED_UPDATED),
-                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7(), LOCK_OWNER_1_EXPIRED, LOCK_OWNER_1_NOT_EXPIRED_UPDATED)
+                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7(), LOCK_OWNER_1_EXPIRED, LOCK_OWNER_1_NOT_EXPIRED_UPDATED),
+                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionSpecialV7(), LOCK_OWNER_1_EXPIRED, LOCK_OWNER_1_NOT_EXPIRED_UPDATED)
         );
     }
 
     public static Stream<Arguments> clusterAndCollection() {
         return Stream.of(
                 Arguments.of(TestcontainersCouchbaseRunner.getCluster6(), TestcontainersCouchbaseRunner.getCollectionV6()),
-                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7())
+                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionV7()),
+                Arguments.of(TestcontainersCouchbaseRunner.getCluster7(), TestcontainersCouchbaseRunner.getCollectionSpecialV7())
         );
     }
 }

--- a/drivers/couchbase/pom.xml
+++ b/drivers/couchbase/pom.xml
@@ -22,8 +22,8 @@
   </modules>
 
   <properties>
-    <couchbase-java-client.version>3.4.4</couchbase-java-client.version>
-    <spring-data-couchbase.version>4.4.8</spring-data-couchbase.version>
+    <couchbase-java-client.version>3.5.2</couchbase-java-client.version>
+    <spring-data-couchbase.version>4.4.18</spring-data-couchbase.version>
   </properties>
 
 </project>


### PR DESCRIPTION
Fixed issue with couchbase driver unable to migrate if collection or scope name had special characters

## Issue reference


## Documentation PR reference

NA

## Description and context

The couchbase driver was not working with couchbase v7+ if the bucket, scope or collection name had a special character like '-'. The main fix is in the `N1QLQueryProvider.java` file, just added an escape for the scope and collection.

## Benefits

Couchbase driver can be used with buckets, scope and collections having special characters in their name (like -).

## Possible Drawbacks

None

## Checklist 
- [x] Unit tests provided
- [ ] Integration tests provided 
- [ ] Documentation updated in [documentation project](https://github.com/mongock/mongock-docs)
- [ ] Updated example in [example projects](https://github.com/mongock/mongock-examples)

