### PR TITLE
Use the current thread class loader to load changelog classes

### DIFF
--- a/mongock-core/mongock-runner/mongock-runner-core/src/main/java/io/mongock/runner/core/executor/ChangeExecutorBase.java
+++ b/mongock-core/mongock-runner/mongock-runner-core/src/main/java/io/mongock/runner/core/executor/ChangeExecutorBase.java
@@ -471,7 +471,7 @@ public abstract class ChangeExecutorBase<CONFIG extends ChangeExecutorConfigurat
     List<String> changeLogsScanPackage = new ArrayList<>();
     for (String itemPath : config.getMigrationScanPackage()) {
       try {
-        changeLogsScanClasses.add(ClassLoader.getSystemClassLoader().loadClass(itemPath));
+        changeLogsScanClasses.add(Class.forName(itemPath, false, Thread.currentThread().getContextClassLoader()));
       } catch (ClassNotFoundException e) {
         changeLogsScanPackage.add(itemPath);
       }


### PR DESCRIPTION
## Issue reference

Fixes flamingock/mongock#87

## Description and context

Quarkus use a custom class loader (https://quarkus.io/guides/class-loading-reference), this fix will ensure that we use the correct class loader.

## Benefits

Makes Mongock working with Quarkus

## Possible Drawbacks

I don't think there are drawbacks to this change