### PR TITLE
issue/#676 New "transactional" property in favour of "transactionEnabled" property (deprecated).

### DIFF
--- a/drivers/mongodb/mongodb-springdata-v2-driver/src/main/java/io/mongock/driver/mongodb/springdata/v2/config/SpringDataMongoV2Context.java
+++ b/drivers/mongodb/mongodb-springdata-v2-driver/src/main/java/io/mongock/driver/mongodb/springdata/v2/config/SpringDataMongoV2Context.java
@@ -7,9 +7,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.transaction.PlatformTransactionManager;
-
-import java.util.Optional;
 
 @Configuration
 @ConditionalOnExpression("${mongock.enabled:true}")
@@ -20,8 +17,7 @@ public class SpringDataMongoV2Context extends SpringDataMongoV2ContextBase<Mongo
   @Override
   protected SpringDataMongoV2Driver buildDriver(MongoTemplate mongoTemplate,
                                               MongockConfiguration config,
-                                              MongoDBConfiguration mongoDbConfig,
-                                              Optional<PlatformTransactionManager> txManagerOpt) {
+                                              MongoDBConfiguration mongoDbConfig) {
     return SpringDataMongoV2Driver.withLockStrategy(
         mongoTemplate,
         config.getLockAcquiredForMillis(),

--- a/drivers/mongodb/mongodb-springdata-v2-driver/src/main/java/io/mongock/driver/mongodb/springdata/v2/config/SpringDataMongoV2ContextBase.java
+++ b/drivers/mongodb/mongodb-springdata-v2-driver/src/main/java/io/mongock/driver/mongodb/springdata/v2/config/SpringDataMongoV2ContextBase.java
@@ -31,7 +31,14 @@ public abstract class SpringDataMongoV2ContextBase<CONFIG extends MongockConfigu
   private void setGenericDriverConfig(CONFIG config,
                                       Optional<PlatformTransactionManager> txManagerOpt,
                                       DRIVER driver) {
-    txManagerOpt.filter(tx -> config.getTransactionEnabled().orElse(true)).ifPresent(tx -> driver.enableTransaction());
+    if (config.getTransactional().isPresent()) {
+      if (config.getTransactional().get()) {
+        driver.enableTransaction();
+      }
+    }
+    else {
+      txManagerOpt.filter(tx -> config.getTransactionEnabled().orElse(true)).ifPresent(tx -> driver.enableTransaction());
+    }
     driver.setMigrationRepositoryName(config.getMigrationRepositoryName());
     driver.setLockRepositoryName(config.getLockRepositoryName());
     driver.setIndexCreation(config.isIndexCreation());

--- a/drivers/mongodb/mongodb-springdata-v2-driver/src/main/java/io/mongock/driver/mongodb/springdata/v2/config/SpringDataMongoV2ContextBase.java
+++ b/drivers/mongodb/mongodb-springdata-v2-driver/src/main/java/io/mongock/driver/mongodb/springdata/v2/config/SpringDataMongoV2ContextBase.java
@@ -17,7 +17,7 @@ public abstract class SpringDataMongoV2ContextBase<CONFIG extends MongockConfigu
                                            CONFIG config,
                                            MongoDBConfiguration mongoDbConfig,
                                            Optional<PlatformTransactionManager> txManagerOpt) {
-    DRIVER driver = buildDriver(mongoTemplate, config, mongoDbConfig, txManagerOpt);
+    DRIVER driver = buildDriver(mongoTemplate, config, mongoDbConfig);
     setGenericDriverConfig(config, txManagerOpt, driver);
     setMongoDBConfig(mongoDbConfig, driver);
     driver.initialize();
@@ -26,8 +26,7 @@ public abstract class SpringDataMongoV2ContextBase<CONFIG extends MongockConfigu
 
   protected abstract DRIVER buildDriver(MongoTemplate mongoTemplate,
                                         CONFIG config,
-                                        MongoDBConfiguration mongoDbConfig,
-                                        Optional<PlatformTransactionManager> txManagerOpt);
+                                        MongoDBConfiguration mongoDbConfig);
 
   private void setGenericDriverConfig(CONFIG config,
                                       Optional<PlatformTransactionManager> txManagerOpt,

--- a/drivers/mongodb/mongodb-springdata-v3-driver/src/main/java/io/mongock/driver/mongodb/springdata/v3/config/SpringDataMongoV3Context.java
+++ b/drivers/mongodb/mongodb-springdata-v3-driver/src/main/java/io/mongock/driver/mongodb/springdata/v3/config/SpringDataMongoV3Context.java
@@ -6,9 +6,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.transaction.PlatformTransactionManager;
 
-import java.util.Optional;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 
 @Configuration
@@ -20,8 +18,7 @@ public class SpringDataMongoV3Context extends SpringDataMongoV3ContextBase<Mongo
   @Override
   protected SpringDataMongoV3Driver buildDriver(MongoTemplate mongoTemplate,
                                                 MongockConfiguration config,
-                                                MongoDBConfiguration mongoDbConfig,
-                                                Optional<PlatformTransactionManager> txManagerOpt) {
+                                                MongoDBConfiguration mongoDbConfig) {
     return SpringDataMongoV3Driver.withLockStrategy(
         mongoTemplate,
         config.getLockAcquiredForMillis(),

--- a/drivers/mongodb/mongodb-springdata-v3-driver/src/main/java/io/mongock/driver/mongodb/springdata/v3/config/SpringDataMongoV3ContextBase.java
+++ b/drivers/mongodb/mongodb-springdata-v3-driver/src/main/java/io/mongock/driver/mongodb/springdata/v3/config/SpringDataMongoV3ContextBase.java
@@ -31,7 +31,14 @@ public abstract class SpringDataMongoV3ContextBase<CONFIG extends MongockConfigu
   private void setGenericDriverConfig(CONFIG config,
                                       Optional<PlatformTransactionManager> txManagerOpt,
                                       DRIVER driver) {
-    txManagerOpt.filter(tx -> config.getTransactionEnabled().orElse(true)).ifPresent(tx -> driver.enableTransaction());
+    if (config.getTransactional().isPresent()) {
+      if (config.getTransactional().get()) {
+        driver.enableTransaction();
+      }
+    }
+    else {
+      txManagerOpt.filter(tx -> config.getTransactionEnabled().orElse(true)).ifPresent(tx -> driver.enableTransaction());
+    }
     driver.setMigrationRepositoryName(config.getMigrationRepositoryName());
     driver.setLockRepositoryName(config.getLockRepositoryName());
     driver.setIndexCreation(config.isIndexCreation());

--- a/drivers/mongodb/mongodb-springdata-v3-driver/src/main/java/io/mongock/driver/mongodb/springdata/v3/config/SpringDataMongoV3ContextBase.java
+++ b/drivers/mongodb/mongodb-springdata-v3-driver/src/main/java/io/mongock/driver/mongodb/springdata/v3/config/SpringDataMongoV3ContextBase.java
@@ -4,8 +4,6 @@ import com.mongodb.ReadConcern;
 import io.mongock.api.config.MongockConfiguration;
 import io.mongock.driver.api.driver.ConnectionDriver;
 import io.mongock.driver.mongodb.springdata.v3.SpringDataMongoV3DriverBase;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -13,14 +11,13 @@ import org.springframework.transaction.PlatformTransactionManager;
 import java.util.Optional;
 
 public abstract class SpringDataMongoV3ContextBase<CONFIG extends MongockConfiguration, DRIVER extends SpringDataMongoV3DriverBase> {
-  private static final Logger logger = LoggerFactory.getLogger(SpringDataMongoV3ContextBase.class);
 
   @Bean
   public ConnectionDriver connectionDriver(MongoTemplate mongoTemplate,
                                            CONFIG config,
                                            MongoDBConfiguration mongoDbConfig,
                                            Optional<PlatformTransactionManager> txManagerOpt) {
-    DRIVER driver = buildDriver(mongoTemplate, config, mongoDbConfig, txManagerOpt);
+    DRIVER driver = buildDriver(mongoTemplate, config, mongoDbConfig);
     setGenericDriverConfig(config, txManagerOpt, driver);
     setMongoDBConfig(mongoDbConfig, driver);
     driver.initialize();
@@ -29,8 +26,7 @@ public abstract class SpringDataMongoV3ContextBase<CONFIG extends MongockConfigu
 
   protected abstract DRIVER buildDriver(MongoTemplate mongoTemplate,
                                         CONFIG config,
-                                        MongoDBConfiguration mongoDbConfig,
-                                        Optional<PlatformTransactionManager> txManagerOpt);
+                                        MongoDBConfiguration mongoDbConfig);
 
   private void setGenericDriverConfig(CONFIG config,
                                       Optional<PlatformTransactionManager> txManagerOpt,

--- a/mongock-core/mongock-api/src/main/java/io/mongock/api/config/MongockConfiguration.java
+++ b/mongock-core/mongock-api/src/main/java/io/mongock/api/config/MongockConfiguration.java
@@ -117,10 +117,18 @@ public class MongockConfiguration implements ExecutorConfiguration {
   private LegacyMigration legacyMigration = null;
 
   /**
+   * @deprecated  As of release 5.5, replaced by {@link #transactional}
    * To enable/disable transactions. It works together with the driver, so enabling transactions with a non-transactional
    * driver or a transactional driver with transaction mode off, will throw a MongockException
    */
+  @Deprecated
   private Boolean transactionEnabled;
+  
+  /**
+   * To enable/disable transactions. It works together with the driver, so enabling transactions with a non-transactional
+   * driver or a transactional driver with transaction mode off, will throw a MongockException
+   */
+  private Boolean transactional;
 
   /**
    * From version 5, author is not a mandatory field, but still needed for backward compatibility. This is why Mongock
@@ -183,6 +191,7 @@ public class MongockConfiguration implements ExecutorConfiguration {
     metadata = from.getMetadata();
     legacyMigration = from.getLegacyMigration();
     transactionEnabled = from.getTransactionEnabled().orElse(null);
+    transactional = from.getTransactional().orElse(null);
     transactionStrategy = from.getTransactionStrategy();
     maxTries = from.getMaxTries();
     maxWaitingForLockMillis = from.getMaxWaitingForLockMillis();
@@ -314,13 +323,13 @@ public class MongockConfiguration implements ExecutorConfiguration {
   public void setMetadata(Map<String, Object> metadata) {
     this.metadata = metadata;
   }
-
-  public Optional<Boolean> getTransactionEnabled() {
-    return Optional.ofNullable(transactionEnabled);
+  
+  public Optional<Boolean> getTransactional() {
+    return Optional.ofNullable(transactional);
   }
 
-  public void setTransactionEnabled(boolean transactionEnabled) {
-    this.transactionEnabled = transactionEnabled;
+  public void setTransactional(boolean transactional) {
+    this.transactional = transactional;
   }
 
   public TransactionStrategy getTransactionStrategy() {
@@ -395,13 +404,14 @@ public class MongockConfiguration implements ExecutorConfiguration {
         Objects.equals(metadata, that.metadata) &&
         Objects.equals(legacyMigration, that.legacyMigration) &&
         Objects.equals(transactionEnabled, that.transactionEnabled) &&
+        Objects.equals(transactional, that.transactional) &&
         Objects.equals(maxTries, that.maxTries) &&
         Objects.equals(maxWaitingForLockMillis, that.maxWaitingForLockMillis);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(migrationRepositoryName, indexCreation, lockRepositoryName, lockAcquiredForMillis, lockQuitTryingAfterMillis, lockTryFrequencyMillis, throwExceptionIfCannotObtainLock, trackIgnored, enabled, migrationScanPackage, startSystemVersion, endSystemVersion, serviceIdentifier, metadata, legacyMigration, transactionEnabled, maxTries, maxWaitingForLockMillis, lockGuardEnabled);
+    return Objects.hash(migrationRepositoryName, indexCreation, lockRepositoryName, lockAcquiredForMillis, lockQuitTryingAfterMillis, lockTryFrequencyMillis, throwExceptionIfCannotObtainLock, trackIgnored, enabled, migrationScanPackage, startSystemVersion, endSystemVersion, serviceIdentifier, metadata, legacyMigration, transactionEnabled, transactional, maxTries, maxWaitingForLockMillis, lockGuardEnabled);
   }
 
   //DEPRECATIONS
@@ -481,5 +491,22 @@ public class MongockConfiguration implements ExecutorConfiguration {
   public void setMaxTries(int maxTries) {
     logger.warn(DEPRECATED_PROPERTY_TEMPLATE, "maxTries", "lockQuitTryingAfterMillis and lockTryFrequencyMillis");
     this.maxTries = maxTries;
+  }
+  
+  /**
+   * Deprecated, uses transactional instead
+   */
+  @Deprecated
+  public Optional<Boolean> getTransactionEnabled() {
+    return Optional.ofNullable(transactionEnabled);
+  }
+
+  /**
+   * Deprecated, uses transactional instead
+   */
+  @Deprecated
+  public void setTransactionEnabled(boolean transactionEnabled) {
+    logger.warn(DEPRECATED_PROPERTY_TEMPLATE, "transactionEnabled", "transactional");
+    this.transactionEnabled = transactionEnabled;
   }
 }

--- a/mongock-core/mongock-api/src/main/java/io/mongock/api/config/executor/ChangeExecutorConfiguration.java
+++ b/mongock-core/mongock-api/src/main/java/io/mongock/api/config/executor/ChangeExecutorConfiguration.java
@@ -13,6 +13,9 @@ public interface ChangeExecutorConfiguration {
 
   boolean isTrackIgnored();
 
+  Optional<Boolean> getTransactional();
+  
+  @Deprecated
   Optional<Boolean> getTransactionEnabled();
   
   TransactionStrategy getTransactionStrategy();

--- a/mongock-core/mongock-runner/mongock-runner-core/src/main/java/io/mongock/runner/core/executor/ChangeExecutorBase.java
+++ b/mongock-core/mongock-runner/mongock-runner-core/src/main/java/io/mongock/runner/core/executor/ChangeExecutorBase.java
@@ -73,6 +73,7 @@ public abstract class ChangeExecutorBase<CONFIG extends ChangeExecutorConfigurat
                                Map<String, Object> metadata,
                                String serviceIdentifier,
                                boolean trackIgnored,
+                               Optional<Boolean> transactional,
                                Optional<Boolean> transactionEnabled,
                                TransactionStrategy transactionStrategy,
                                CONFIG config) {
@@ -84,7 +85,7 @@ public abstract class ChangeExecutorBase<CONFIG extends ChangeExecutorConfigurat
     this.metadata = metadata;
     this.serviceIdentifier = serviceIdentifier;
     this.trackIgnored = trackIgnored;
-    this.globalTransactionEnabled = transactionEnabled.orElse(null);
+    this.globalTransactionEnabled = transactional.isPresent() ? transactional.get() : transactionEnabled.orElse(null);
     this.transactionStrategy = transactionStrategy;
     this.config = config;
   }

--- a/mongock-core/mongock-runner/mongock-runner-core/src/main/java/io/mongock/runner/core/executor/operation/migrate/MigrateExecutorBase.java
+++ b/mongock-core/mongock-runner/mongock-runner-core/src/main/java/io/mongock/runner/core/executor/operation/migrate/MigrateExecutorBase.java
@@ -35,6 +35,7 @@ public abstract class MigrateExecutorBase extends ChangeExecutorBase<ChangeExecu
           config.getMetadata(),
           config.getServiceIdentifier(),
           config.isTrackIgnored(),
+          config.getTransactional(),
           config.getTransactionEnabled(),
           config.getTransactionStrategy(),
           config);

--- a/mongock-core/mongock-runner/mongock-runner-core/src/main/java/io/mongock/runner/core/executor/system/SystemUpdateExecutor.java
+++ b/mongock-core/mongock-runner/mongock-runner-core/src/main/java/io/mongock/runner/core/executor/system/SystemUpdateExecutor.java
@@ -44,6 +44,7 @@ public class SystemUpdateExecutor<CONFIG extends MongockConfiguration> extends C
           null,
           config.getServiceIdentifier(),
           false,
+          config.getTransactional(),
           config.getTransactionEnabled(),
           TransactionStrategy.CHANGE_UNIT,
           config);


### PR DESCRIPTION
issue/#676 New "transactional" property in favour of "transactionEnabled" property (deprecated). When using "transactional" property, Mongock will not use the "TransactionManager" to enable/disable transactions in MongoDB SpringData drivers.