### PR TITLE
Remove unused getResidualKey local variable.

### DIFF
--- a/drivers/mongodb/mongodb-reactive-driver/src/main/java/io/mongock/driver/mongodb/reactive/repository/MongoReactiveRepositoryBase.java
+++ b/drivers/mongodb/mongodb-reactive-driver/src/main/java/io/mongock/driver/mongodb/reactive/repository/MongoReactiveRepositoryBase.java
@@ -71,7 +71,6 @@ public abstract class MongoReactiveRepositoryBase<DOMAIN_CLASS> implements Entit
   }
 
   private List<Document> getResidualKeys() {
-    SubscriberSync<Document> subscriber = new MongoSubscriberSync<>();
     return collection.listIndexes()
         .stream()
         .filter(this::doesNeedToBeRemoved)


### PR DESCRIPTION
## Issue reference

# [Reference or link to the issue covered in the PR]  
No specific issue referenced. This is part of ongoing code quality improvement.

## Documentation PR reference

# No documentation update is needed for this change as it’s an internal code refactor.

# [Documentation project](https://github.com/mongock/mongock-docs)

## Description and context

# This change removes an unused local variable in the `getResidualKeys` method, which was identified as a code smell. The variable `subscriber` was defined but never utilized in the method, contributing unnecessary clutter. Removing it enhances code readability and maintainability.

## Benefits

# Cleaner and more maintainable code.
# Slight performance improvement by avoiding unnecessary object creation.
# Reduces potential confusion for future maintainers or developers.

## Possible Drawbacks

# No significant drawbacks are expected as this change does not alter any logic or behavior of the application.

## Checklist 
- [ ] Unit tests provided (not applicable for this refactor)
- [ ] Integration tests provided (not applicable for this refactor)
- [] Documentation updated in [documentation project](https://github.com/mongock/mongock-docs) (not needed for this change)
- [ ] Updated example in [example projects](https://github.com/mongock/mongock-examples) (not needed for this change)
