### PR TITLE
issue/#700 Allow writeConcern to be configured as a number

### DIFF
--- a/drivers/mongodb/mongodb-springdata-v3-driver/src/main/java/io/mongock/driver/mongodb/springdata/v3/config/MongoDBConfiguration.java
+++ b/drivers/mongodb/mongodb-springdata-v3-driver/src/main/java/io/mongock/driver/mongodb/springdata/v3/config/MongoDBConfiguration.java
@@ -44,7 +44,13 @@ public class MongoDBConfiguration {
   }
 
   protected WriteConcern getBuiltMongoDBWriteConcern() {
-    WriteConcern wc = new WriteConcern(writeConcern.w).withJournal(writeConcern.journal);
+    WriteConcern wc;
+    try {
+      int wInt = Integer.parseInt(writeConcern.w);
+      wc = new WriteConcern(wInt).withJournal(writeConcern.journal);
+    } catch (NumberFormatException e) {
+      wc = new WriteConcern(writeConcern.w).withJournal(writeConcern.journal);
+    }
     return writeConcern.getwTimeoutMs() == null
         ? wc
         : wc.withWTimeout(writeConcern.getwTimeoutMs().longValue(), TimeUnit.MILLISECONDS);

--- a/drivers/mongodb/mongodb-springdata-v3-driver/src/test/java/io/mongock/driver/mongodb/springdata/v3/config/MongoDBConfigurationTest.java
+++ b/drivers/mongodb/mongodb-springdata-v3-driver/src/test/java/io/mongock/driver/mongodb/springdata/v3/config/MongoDBConfigurationTest.java
@@ -1,0 +1,64 @@
+package io.mongock.driver.mongodb.springdata.v3.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import com.mongodb.WriteConcern;
+
+public class MongoDBConfigurationTest {
+
+  @Test
+  public void writeConcern_defaultValuesTest() {
+    MongoDBConfiguration mongoConfig = new MongoDBConfiguration();
+
+    WriteConcern actual = mongoConfig.getBuiltMongoDBWriteConcern();
+    WriteConcern expected = WriteConcern.MAJORITY.withJournal(true);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void writeConcern_majorityWithTimeoutAndJournalFalseTest() {
+    MongoDBConfiguration mongoConfig = new MongoDBConfiguration();
+    mongoConfig.setWriteConcern(
+        new MongoDBConfiguration.WriteConcernLevel("majority", 1000, false)
+    );
+
+    WriteConcern actual = mongoConfig.getBuiltMongoDBWriteConcern();
+    WriteConcern expected = WriteConcern.MAJORITY
+        .withWTimeout(1000, TimeUnit.MILLISECONDS)
+        .withJournal(false);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void writeConcern_w1WithTimeoutJournalTrueTest() {
+    MongoDBConfiguration mongoConfig = new MongoDBConfiguration();
+    mongoConfig.setWriteConcern(
+        new MongoDBConfiguration.WriteConcernLevel("1", 2000, true)
+    );
+
+    WriteConcern actual = mongoConfig.getBuiltMongoDBWriteConcern();
+    WriteConcern expected = WriteConcern.W1
+        .withWTimeout(2000, TimeUnit.MILLISECONDS)
+        .withJournal(true);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void writeConcern_replicaSetTagNameTest() {
+    MongoDBConfiguration mongoConfig = new MongoDBConfiguration();
+    mongoConfig.setWriteConcern(
+        new MongoDBConfiguration.WriteConcernLevel("12-TAG-34", null, null)
+    );
+
+    WriteConcern actual = mongoConfig.getBuiltMongoDBWriteConcern();
+    WriteConcern expected = new WriteConcern("12-TAG-34");
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+}


### PR DESCRIPTION
## Issue reference

https://github.com/mongock/mongock/discussions/700

## Documentation PR reference

No documentation change

## Description and context

Creates WriteConcern using alternate constructor

## Benefits

Allows WriteConcern as {w: 1}

## Possible Drawbacks

Possibly If somebody actively used https://www.mongodb.com/docs/manual/tutorial/configure-replica-set-tag-sets/ with tag = numeric value. Instead of wanting to rely on W1, W2 ,etc

## Checklist 
- [ ] Unit tests provided
- [ ] Integration tests provided 
- [ ] Documentation updated in [documentation project](https://github.com/mongock/mongock-docs)
- [ ] Updated example in [example projects](https://github.com/mongock/mongock-examples)

