### PR TITLE
fix: add missing sql audit store module to build.gradle

### DIFF
--- a/buildSrc/src/main/kotlin/flamingock.project-structure.gradle.kts
+++ b/buildSrc/src/main/kotlin/flamingock.project-structure.gradle.kts
@@ -23,6 +23,7 @@ val communityProjects = setOf(
     "flamingock-auditstore-mongodb-sync",
     "flamingock-auditstore-couchbase",
     "flamingock-auditstore-dynamodb",
+    "flamingock-auditstore-sql",
     "flamingock-importer"
 )
 

--- a/community/flamingock-community-bom/build.gradle.kts
+++ b/community/flamingock-community-bom/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
         api("io.flamingock:flamingock-auditstore-mongodb-springdata:${version}")
         api("io.flamingock:flamingock-auditstore-couchbase:$version")
         api("io.flamingock:flamingock-auditstore-dynamodb:$version")
+        api("io.flamingock:flamingock-auditstore-sql:$version")
         api("io.flamingock:flamingock-sql-template:$version")
         api("io.flamingock:flamingock-mongodb-sync-template:${version}")
         api("io.flamingock:flamingock-springboot-integration:${version}")

--- a/community/flamingock-community/build.gradle.kts
+++ b/community/flamingock-community/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     api(project(":community:flamingock-auditstore-couchbase"))
     api(project(":community:flamingock-auditstore-dynamodb"))
     api(project(":community:flamingock-auditstore-mongodb-sync"))
+    api(project(":community:flamingock-auditstore-sql"))
 }
 
 description = "Community Edition aggregate module providing self-managed audit capabilities"

--- a/core/importer/flamingock-importer/build.gradle.kts
+++ b/core/importer/flamingock-importer/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     testImplementation(project(":community:flamingock-auditstore-mongodb-sync"))
     testImplementation(project(":templates:flamingock-mongodb-sync-template"))
     testImplementation(project(":community:flamingock-auditstore-dynamodb"))
+
     testImplementation(project(":utils:test-util"))
     testImplementation("org.testcontainers:mongodb:1.18.3")
     testImplementation("org.testcontainers:junit-jupiter:1.18.3")


### PR DESCRIPTION
fix: add missing sql audit store module to build.gradle