### PR TITLE
fix(processor): avoid re-processing EnableFlamingock annotation in later rounds

### DIFF
--- a/core/flamingock-processor/src/main/java/io/flamingock/core/processor/FlamingockAnnotationProcessor.java
+++ b/core/flamingock-processor/src/main/java/io/flamingock/core/processor/FlamingockAnnotationProcessor.java
@@ -152,7 +152,7 @@ public class FlamingockAnnotationProcessor extends AbstractProcessor {
     );
 
 
-    private static final boolean hasProcessed = false;
+    private static boolean hasProcessed = false;
 
     private String resourcesRoot = null;
     private List<String> sourceRoots = null;
@@ -215,6 +215,7 @@ public class FlamingockAnnotationProcessor extends AbstractProcessor {
         FlamingockMetadata flamingockMetadata = new FlamingockMetadata(pipeline, setup, configFile);
         serializer.serializeFullPipeline(flamingockMetadata);
         logger.info("Finished processing annotated classes and generating metadata.");
+        hasProcessed = true;
         return true;
     }
 


### PR DESCRIPTION
Previously the Flamingock annotation processor was executed on every
round. When used together with Lombok, the @EnableFlamingock annotation
could be removed in a later round, causing the processor to fail.

This change ensures the processor runs only when needed, preventing
the issue triggered when Lombok rewrites annotated classes.

Closes #729.
