### PR TITLE
chore: add oracle dialect by default to sql audit store test run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Unit and Integration tests
         run: |
           ./gradlew clean build \
-            -Psql.test.dialects=mysql
+            -Psql.test.dialects=mysql,oracle

--- a/community/flamingock-auditstore-sql/build.gradle.kts
+++ b/community/flamingock-auditstore-sql/build.gradle.kts
@@ -40,7 +40,7 @@ configurations.testImplementation {
 tasks.test {
     // CI-specific configuration
     val isCI = System.getenv("CI")?.toBoolean() ?: false
-    val enabledDialects = System.getProperty("sql.test.dialects") ?: if (isCI) "mysql" else "mysql,postgresql,mariadb"
+    val enabledDialects = System.getProperty("sql.test.dialects") ?: if (isCI) "mysql" else "mysql,oracle"
 
     systemProperty("sql.test.dialects", enabledDialects)
 

--- a/community/flamingock-auditstore-sql/build.gradle.kts
+++ b/community/flamingock-auditstore-sql/build.gradle.kts
@@ -40,7 +40,7 @@ configurations.testImplementation {
 tasks.test {
     // CI-specific configuration
     val isCI = System.getenv("CI")?.toBoolean() ?: false
-    val enabledDialects = System.getProperty("sql.test.dialects") ?: if (isCI) "mysql" else "mysql,oracle"
+    val enabledDialects = System.getProperty("sql.test.dialects") ?: if (isCI) "mysql,oracle" else "mysql,oracle,sqlserver"
 
     systemProperty("sql.test.dialects", enabledDialects)
 

--- a/community/flamingock-auditstore-sql/src/test/java/io/flamingock/community/sql/SharedSqlContainers.java
+++ b/community/flamingock-auditstore-sql/src/test/java/io/flamingock/community/sql/SharedSqlContainers.java
@@ -64,8 +64,9 @@ public final class SharedSqlContainers {
                     }
                 }
                         .withPassword("oracle123")
-                        .withSharedMemorySize(1073741824L)
-                        .withStartupTimeout(Duration.ofMinutes(20))
+                        .withSharedMemorySize(2147483648L)
+                        .withStartupTimeout(Duration.ofMinutes(10))
+                        .withStartupAttempts(2)
                         .waitingFor(new WaitAllStrategy()
                                 .withStrategy(Wait.forListeningPort())
                                 .withStrategy(Wait.forLogMessage(".*DATABASE IS READY TO USE.*\\n", 1))


### PR DESCRIPTION
chore: add oracle dialect by default to sql audit store test run