### PR TITLE
fix: delegate property resolution in PriorityContextResolver

### DIFF
--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/context/AbstractSimpleContextResolver.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/context/AbstractSimpleContextResolver.java
@@ -23,7 +23,7 @@ import io.flamingock.internal.common.core.context.DependencyBuildable;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-public abstract class AbstractContextResolver implements ContextResolver {
+public abstract class AbstractSimpleContextResolver implements ContextResolver {
 
     @Override
     public Optional<Dependency> getDependency(Class<?> type) {

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/context/PriorityContextResolver.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/context/PriorityContextResolver.java
@@ -78,7 +78,7 @@ public class PriorityContextResolver implements ContextResolver {
      */
     @Override
     public Optional<String> getProperty(String key) {
-        return getDependencyValue(key, String.class);
+        return getPropertyAs(key, String.class);
     }
 
     /**
@@ -92,6 +92,11 @@ public class PriorityContextResolver implements ContextResolver {
      */
     @Override
     public <T> Optional<T> getPropertyAs(String key, Class<T> type) {
-        return getDependencyValue(key, type);
+        Optional<T> dependencyValue = getDependencyValue(key, type);
+        if (dependencyValue.isPresent()) {
+            return dependencyValue;
+        } else {
+            return baseContext.getPropertyAs(key, type);
+        }
     }
 }

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/context/SimpleContext.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/context/SimpleContext.java
@@ -44,7 +44,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-public class SimpleContext extends AbstractContextResolver implements Context {
+public class SimpleContext extends AbstractSimpleContextResolver implements Context {
 
     private final Map<String, Dependency> dependenciesByName;
     private final Map<Class<?>, Dependency> dependenciesByExactType;

--- a/core/flamingock-core/src/test/java/io/flamingock/internal/core/context/PriorityContextResolverPropertyTest.java
+++ b/core/flamingock-core/src/test/java/io/flamingock/internal/core/context/PriorityContextResolverPropertyTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Flamingock (https://www.flamingock.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.flamingock.internal.core.context;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests proving that {@link PriorityContextResolver} fails to delegate property resolution
+ * to the base context when that context keeps dependencies and properties in separate stacks.
+ * <p>
+ * The bug: {@code getPropertyAs()} routes through {@code getDependencyValue(name, type)} which calls
+ * {@code getDependency(name)}, never reaching the base context's {@code getProperty()}/{@code getPropertyAs()}.
+ * This works for {@link SimpleContext} (which stores properties as dependencies) but breaks for any
+ * {@code ContextResolver} that separates the two (like {@code SpringbootDependencyContext}).
+ */
+class PriorityContextResolverPropertyTest {
+
+    @Test
+    @DisplayName("Should resolve property from base context when property is in a separate stack (not a dependency)")
+    void shouldResolvePropertyFromBaseContext_whenPropertyInSeparateStack() {
+        // Given: a base context that stores properties separately from dependencies
+        SplitStackContextResolver splitStackContext = new SplitStackContextResolver();
+        splitStackContext.addProperty("timeout", "5000");
+
+        // When: wrapped in PriorityContextResolver as the base context
+        PriorityContextResolver priorityResolver = new PriorityContextResolver(new SimpleContext(), splitStackContext);
+
+        // Then: the property should be resolvable
+        Optional<String> result = priorityResolver.getProperty("timeout");
+        assertTrue(result.isPresent(), "Property 'timeout' should be present but was empty");
+        assertEquals("5000", result.get());
+    }
+
+    @Test
+    @DisplayName("Should resolve both dependency and property from base context when both exist in separate stacks")
+    void shouldResolvePropertyFromBaseContext_whenDependencyAlsoExists() {
+        // Given: a base context with both a dependency (bean) and a property in separate stacks
+        SplitStackContextResolver splitStackContext = new SplitStackContextResolver();
+        splitStackContext.addDependency("myService", Runnable.class, (Runnable) () -> {});
+        splitStackContext.addProperty("timeout", "5000");
+
+        PriorityContextResolver priorityResolver = new PriorityContextResolver(new SimpleContext(), splitStackContext);
+
+        // Sanity: the dependency IS resolvable through the priority context
+        assertTrue(priorityResolver.getDependency(Runnable.class).isPresent(),
+                "Dependency should be resolvable through PriorityContextResolver");
+
+        // Then: the property should also be resolvable
+        Optional<String> result = priorityResolver.getProperty("timeout");
+        assertTrue(result.isPresent(), "Property 'timeout' should be present but was empty");
+        assertEquals("5000", result.get());
+    }
+
+    @Test
+    @DisplayName("Should resolve property from priority context when set via SimpleContext.setProperty (control test)")
+    void shouldResolvePropertyFromPriorityContext_whenPropertySetAsProperty() {
+        // Given: a SimpleContext (priority) with a property set directly
+        // In SimpleContext, setProperty stores it as a dependency, so getDependencyValue works
+        SimpleContext simpleContext = new SimpleContext();
+        simpleContext.setProperty("timeout", "5000");
+
+        PriorityContextResolver priorityResolver = new PriorityContextResolver(simpleContext, new SimpleContext());
+
+        // Then: this DOES work because SimpleContext stores properties as dependencies
+        Optional<String> result = priorityResolver.getProperty("timeout");
+        assertTrue(result.isPresent(), "Property 'timeout' should be present");
+        assertEquals("5000", result.get());
+    }
+}

--- a/core/flamingock-core/src/test/java/io/flamingock/internal/core/context/SplitStackContextResolver.java
+++ b/core/flamingock-core/src/test/java/io/flamingock/internal/core/context/SplitStackContextResolver.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Flamingock (https://www.flamingock.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.flamingock.internal.core.context;
+
+import io.flamingock.internal.common.core.context.ContextResolver;
+import io.flamingock.internal.common.core.context.Dependency;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A test helper {@link ContextResolver} that keeps dependencies and properties in separate stacks,
+ * simulating the pattern used by framework integrations (Spring Boot, Quarkus, etc.) where beans
+ * come from one source and configuration properties from another.
+ * <p>
+ * This is intentionally NOT backed by {@link AbstractSimpleContextResolver} or {@link SimpleContext},
+ * so that properties stored via {@link #addProperty} are NOT resolvable through {@code getDependency()}.
+ */
+class SplitStackContextResolver implements ContextResolver {
+
+    private final Map<String, Dependency> dependenciesByName = new HashMap<>();
+    private final Map<Class<?>, Dependency> dependenciesByType = new HashMap<>();
+    private final Map<String, String> properties = new HashMap<>();
+
+    void addDependency(String name, Class<?> type, Object instance) {
+        Dependency dep = new Dependency(name, type, instance);
+        dependenciesByName.put(name, dep);
+        dependenciesByType.put(type, dep);
+    }
+
+    void addProperty(String key, String value) {
+        properties.put(key, value);
+    }
+
+    @Override
+    public Optional<Dependency> getDependency(Class<?> type) {
+        return Optional.ofNullable(dependenciesByType.get(type));
+    }
+
+    @Override
+    public Optional<Dependency> getDependency(String name) {
+        return Optional.ofNullable(dependenciesByName.get(name));
+    }
+
+    @Override
+    public Optional<String> getProperty(String key) {
+        return Optional.ofNullable(properties.get(key));
+    }
+
+    @Override
+    public <T> Optional<T> getPropertyAs(String key, Class<T> type) {
+        String value = properties.get(key);
+        if (value == null) {
+            return Optional.empty();
+        }
+        return Optional.of(type.cast(value));
+    }
+}

--- a/platform-plugins/flamingock-springboot-integration/src/main/java/io/flamingock/springboot/SpringbootDependencyContext.java
+++ b/platform-plugins/flamingock-springboot-integration/src/main/java/io/flamingock/springboot/SpringbootDependencyContext.java
@@ -83,7 +83,7 @@ public class SpringbootDependencyContext implements ContextResolver {
      */
     @Override
     public Optional<String> getProperty(String key) {
-        return Optional.ofNullable(environment.getProperty(flamingockKey(key)));
+        return Optional.ofNullable(environment.getProperty(key));
     }
 
     /**
@@ -97,16 +97,8 @@ public class SpringbootDependencyContext implements ContextResolver {
      */
     @Override
     public <T> Optional<T> getPropertyAs(String key, Class<T> type) {
-        return Optional.ofNullable(environment.getProperty(flamingockKey(key), type));
+        return Optional.ofNullable(environment.getProperty(key, type));
     }
 
-    /**
-     * Adds the {@code flamingock.} namespace prefix to the property key.
-     *
-     * @param key the raw property key
-     * @return the fully qualified key with the {@code flamingock.} prefix
-     */
-    private static String flamingockKey(String key) {
-        return "flamingock." + key;
-    }
+
 }

--- a/platform-plugins/flamingock-springboot-integration/src/test/java/io/flamingock/springboot/SpringbootPropertyResolutionTest.java
+++ b/platform-plugins/flamingock-springboot-integration/src/test/java/io/flamingock/springboot/SpringbootPropertyResolutionTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Flamingock (https://www.flamingock.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.flamingock.springboot;
+
+import io.flamingock.internal.core.context.PriorityContextResolver;
+import io.flamingock.internal.core.context.SimpleContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests proving that {@link PriorityContextResolver} fails to resolve Spring Environment properties
+ * through {@link SpringbootDependencyContext}, because it routes property resolution through the
+ * dependency path ({@code getDependencyValue} → {@code getDependency}) instead of delegating to
+ * the context's {@code getProperty()}/{@code getPropertyAs()}.
+ */
+class SpringbootPropertyResolutionTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withPropertyValues("flamingock.timeout=5000");
+
+    @Test
+    @DisplayName("Should resolve Spring property through PriorityContextResolver")
+    void shouldResolveSpringPropertyThroughPriorityContext() {
+        contextRunner.run(ctx -> {
+            SpringbootDependencyContext springbootContext = new SpringbootDependencyContext(ctx);
+
+            // Sanity: direct call to SpringbootDependencyContext works
+            Optional<String> directResult = springbootContext.getProperty("flamingock.timeout");
+            assertTrue(directResult.isPresent(), "Direct getProperty on SpringbootDependencyContext should work");
+            assertEquals("5000", directResult.get());
+
+            // Bug: when wrapped in PriorityContextResolver, property resolution breaks
+            PriorityContextResolver priorityResolver = new PriorityContextResolver(new SimpleContext(), springbootContext);
+            Optional<String> result = priorityResolver.getProperty("flamingock.timeout");
+
+            assertTrue(result.isPresent(), "Property 'timeout' should be resolvable through PriorityContextResolver");
+            assertEquals("5000", result.get());
+        });
+    }
+
+    @Test
+    @DisplayName("Should resolve Spring bean through PriorityContextResolver (control test)")
+    void shouldResolveSpringBeanThroughPriorityContext() {
+        contextRunner
+                .withUserConfiguration(BeanConfiguration.class)
+                .run(ctx -> {
+                    SpringbootDependencyContext springbootContext = new SpringbootDependencyContext(ctx);
+                    PriorityContextResolver priorityResolver = new PriorityContextResolver(new SimpleContext(), springbootContext);
+
+                    // Bean resolution DOES work through PriorityContextResolver
+                    assertTrue(priorityResolver.getDependency(Runnable.class).isPresent(),
+                            "Spring bean should be resolvable through PriorityContextResolver");
+                });
+    }
+
+    @Configuration
+    static class BeanConfiguration {
+        @Bean
+        public Runnable testService() {
+            return () -> {};
+        }
+    }
+}


### PR DESCRIPTION
Route getProperty/getPropertyAs through the base context's property
methods instead of getDependencyValue, which only resolves dependencies
