### PR TITLE
feat(template): payload validation

### DIFF
--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/template/AbstractChangeTemplate.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/template/AbstractChangeTemplate.java
@@ -39,7 +39,7 @@ import java.util.Set;
  * @param <ROLLBACK_FIELD> rollback payload type
  * @see io.flamingock.api.annotations.ChangeTemplate
  */
-public abstract class AbstractChangeTemplate<SHARED_CONFIGURATION_FIELD, APPLY_FIELD, ROLLBACK_FIELD> implements ChangeTemplate<SHARED_CONFIGURATION_FIELD, APPLY_FIELD, ROLLBACK_FIELD> {
+public abstract class AbstractChangeTemplate<SHARED_CONFIGURATION_FIELD, APPLY_FIELD extends TemplatePayload, ROLLBACK_FIELD extends TemplatePayload> implements ChangeTemplate<SHARED_CONFIGURATION_FIELD, APPLY_FIELD, ROLLBACK_FIELD> {
 
     private final Class<SHARED_CONFIGURATION_FIELD> configurationClass;
     private final Class<APPLY_FIELD> applyPayloadClass;

--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/template/ChangeTemplate.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/template/ChangeTemplate.java
@@ -28,7 +28,7 @@ package io.flamingock.api.template;
  * @see AbstractChangeTemplate
  * @see io.flamingock.api.annotations.ChangeTemplate
  */
-public interface ChangeTemplate<SHARED_CONFIG_FIELD, APPLY_FIELD, ROLLBACK_FIELD> extends ReflectionMetadataProvider {
+public interface ChangeTemplate<SHARED_CONFIG_FIELD, APPLY_FIELD extends TemplatePayload, ROLLBACK_FIELD extends TemplatePayload> extends ReflectionMetadataProvider {
 
     void setChangeId(String changeId);
 

--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/template/TemplatePayload.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/template/TemplatePayload.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Flamingock (https://www.flamingock.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.flamingock.api.template;
+
+import java.util.List;
+
+/**
+ * Contract for template payload types (APPLY and ROLLBACK generics).
+ *
+ * <p>All template payload types must implement this interface to enable
+ * structural validation at pipeline load time, before any change executes.
+ */
+public interface TemplatePayload {
+
+    /**
+     * Validates this payload and returns any errors found.
+     *
+     * @return list of validation errors, empty if payload is valid
+     */
+    List<TemplatePayloadValidationError> validate();
+}

--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/template/TemplatePayloadValidationError.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/template/TemplatePayloadValidationError.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Flamingock (https://www.flamingock.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.flamingock.api.template;
+
+/**
+ * Represents a validation error found in a {@link TemplatePayload}.
+ *
+ * <p>Errors can be field-level (with a specific field name) or general (without a field).
+ */
+public class TemplatePayloadValidationError {
+
+    private final String field;
+    private final String message;
+
+    public TemplatePayloadValidationError(String message) {
+        this(null, message);
+    }
+
+    public TemplatePayloadValidationError(String field, String message) {
+        this.field = field;
+        this.message = message;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getFormattedMessage() {
+        return field != null ? String.format("[field: %s] %s", field, message) : message;
+    }
+
+    @Override
+    public String toString() {
+        return getFormattedMessage();
+    }
+}

--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/template/wrappers/TemplateString.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/template/wrappers/TemplateString.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Flamingock (https://www.flamingock.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.flamingock.api.template.wrappers;
+
+import io.flamingock.api.template.TemplatePayload;
+import io.flamingock.api.template.TemplatePayloadValidationError;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@link TemplatePayload} wrapper for {@code String} payloads.
+ *
+ * <p>Provides a drop-in replacement for raw {@code String} payloads in templates,
+ * keeping YAML clean while satisfying the {@code TemplatePayload} contract.
+ *
+ * <p>Supports SnakeYAML deserialization via the no-arg constructor and scalar
+ * conversion via the {@code String} constructor.
+ */
+public class TemplateString implements TemplatePayload {
+
+    private String value;
+
+    /**
+     * No-arg constructor for SnakeYAML deserialization.
+     */
+    public TemplateString() {
+    }
+
+    /**
+     * Constructor for scalar conversion (e.g., from YAML string values).
+     *
+     * @param value the string value
+     */
+    public TemplateString(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public List<TemplatePayloadValidationError> validate() {
+        if (value == null || value.trim().isEmpty()) {
+            return Collections.singletonList(
+                    new TemplatePayloadValidationError("value", "must not be null or blank"));
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TemplateString that = (TemplateString) o;
+        return value != null ? value.equals(that.value) : that.value == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return value != null ? value.hashCode() : 0;
+    }
+}

--- a/core/flamingock-core-api/src/test/java/io/flamingock/api/template/AbstractChangeTemplateReflectiveClassesTest.java
+++ b/core/flamingock-core-api/src/test/java/io/flamingock/api/template/AbstractChangeTemplateReflectiveClassesTest.java
@@ -18,10 +18,13 @@ package io.flamingock.api.template;
 import io.flamingock.api.annotations.Apply;
 import io.flamingock.api.annotations.ChangeTemplate;
 import io.flamingock.api.annotations.Rollback;
+import io.flamingock.api.template.wrappers.TemplateString;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -33,13 +36,23 @@ class AbstractChangeTemplateReflectiveClassesTest {
     }
 
     // Simple test apply payload class
-    public static class TestApplyPayload {
+    public static class TestApplyPayload implements TemplatePayload {
         public String applyData;
+
+        @Override
+        public List<TemplatePayloadValidationError> validate() {
+            return Collections.emptyList();
+        }
     }
 
     // Simple test rollback payload class
-    public static class TestRollbackPayload {
+    public static class TestRollbackPayload implements TemplatePayload {
         public String rollbackData;
+
+        @Override
+        public List<TemplatePayloadValidationError> validate() {
+            return Collections.emptyList();
+        }
     }
 
     // Additional class for reflection
@@ -93,7 +106,7 @@ class AbstractChangeTemplateReflectiveClassesTest {
     // Test template with Void configuration
     @ChangeTemplate(name = "test-template-with-void-config")
     public static class TestTemplateWithVoidConfig
-            extends AbstractChangeTemplate<Void, String, String> {
+            extends AbstractChangeTemplate<Void, TemplateString, TemplateString> {
 
         public TestTemplateWithVoidConfig() {
             super();
@@ -191,8 +204,8 @@ class AbstractChangeTemplateReflectiveClassesTest {
 
         assertTrue(reflectiveClasses.contains(Void.class),
                 "Should contain Void class for configuration");
-        assertTrue(reflectiveClasses.contains(String.class),
-                "Should contain String class for apply/rollback payloads");
+        assertTrue(reflectiveClasses.contains(TemplateString.class),
+                "Should contain TemplateString class for apply/rollback payloads");
     }
 
     @Test

--- a/core/flamingock-core-commons/src/test/java/io/flamingock/internal/common/core/template/ChangeTemplateManagerTest.java
+++ b/core/flamingock-core-commons/src/test/java/io/flamingock/internal/common/core/template/ChangeTemplateManagerTest.java
@@ -19,6 +19,7 @@ import io.flamingock.api.annotations.Apply;
 import io.flamingock.api.annotations.ChangeTemplate;
 import io.flamingock.api.annotations.Rollback;
 import io.flamingock.api.template.AbstractChangeTemplate;
+import io.flamingock.api.template.wrappers.TemplateString;
 import io.flamingock.internal.common.core.error.FlamingockException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class ChangeTemplateManagerTest {
 
     @ChangeTemplate(name = "annotated-simple-template")
-    public static class AnnotatedSimpleTemplate extends AbstractChangeTemplate<Void, String, String> {
+    public static class AnnotatedSimpleTemplate extends AbstractChangeTemplate<Void, TemplateString, TemplateString> {
         public AnnotatedSimpleTemplate() {
             super();
         }
@@ -45,7 +46,7 @@ class ChangeTemplateManagerTest {
     }
 
     @ChangeTemplate(name = "annotated-steppable-template", multiStep = true)
-    public static class AnnotatedSteppableTemplate extends AbstractChangeTemplate<Void, String, String> {
+    public static class AnnotatedSteppableTemplate extends AbstractChangeTemplate<Void, TemplateString, TemplateString> {
         public AnnotatedSteppableTemplate() {
             super();
         }
@@ -59,7 +60,7 @@ class ChangeTemplateManagerTest {
         }
     }
 
-    public static class UnannotatedTemplate extends AbstractChangeTemplate<Void, String, String> {
+    public static class UnannotatedTemplate extends AbstractChangeTemplate<Void, TemplateString, TemplateString> {
         public UnannotatedTemplate() {
             super();
         }
@@ -113,7 +114,7 @@ class ChangeTemplateManagerTest {
     }
 
     @ChangeTemplate(name = "template-rollback-not-required", rollbackPayloadRequired = false)
-    public static class TemplateWithRollbackNotRequired extends AbstractChangeTemplate<Void, String, String> {
+    public static class TemplateWithRollbackNotRequired extends AbstractChangeTemplate<Void, TemplateString, TemplateString> {
         public TemplateWithRollbackNotRequired() {
             super();
         }
@@ -140,7 +141,7 @@ class ChangeTemplateManagerTest {
     }
 
     @ChangeTemplate(name = "template-without-rollback")
-    public static class TemplateWithoutRollback extends AbstractChangeTemplate<Void, String, String> {
+    public static class TemplateWithoutRollback extends AbstractChangeTemplate<Void, TemplateString, TemplateString> {
         public TemplateWithoutRollback() {
             super();
         }

--- a/core/flamingock-core-commons/src/test/java/io/flamingock/internal/common/core/template/TemplateValidatorTest.java
+++ b/core/flamingock-core-commons/src/test/java/io/flamingock/internal/common/core/template/TemplateValidatorTest.java
@@ -19,6 +19,7 @@ import io.flamingock.api.annotations.Apply;
 import io.flamingock.api.annotations.ChangeTemplate;
 import io.flamingock.api.annotations.Rollback;
 import io.flamingock.api.template.AbstractChangeTemplate;
+import io.flamingock.api.template.wrappers.TemplateString;
 import io.flamingock.internal.common.core.error.validation.ValidationResult;
 import io.flamingock.internal.common.core.preview.TemplatePreviewChange;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,7 +41,7 @@ class TemplateValidatorTest {
 
     // Test template with @ChangeTemplate (simple template)
     @ChangeTemplate(name = "test-simple-template")
-    public static class TestSimpleTemplate extends AbstractChangeTemplate<Void, String, String> {
+    public static class TestSimpleTemplate extends AbstractChangeTemplate<Void, TemplateString, TemplateString> {
         public TestSimpleTemplate() {
             super();
         }
@@ -57,7 +58,7 @@ class TemplateValidatorTest {
 
     // Test template with @ChangeTemplate(multiStep = true)
     @ChangeTemplate(name = "test-steppable-template", multiStep = true)
-    public static class TestSteppableTemplate extends AbstractChangeTemplate<Void, String, String> {
+    public static class TestSteppableTemplate extends AbstractChangeTemplate<Void, TemplateString, TemplateString> {
         public TestSteppableTemplate() {
             super();
         }

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/AbstractTemplateExecutableTask.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/AbstractTemplateExecutableTask.java
@@ -16,6 +16,7 @@
 package io.flamingock.internal.core.task.executable;
 
 import io.flamingock.api.template.ChangeTemplate;
+import io.flamingock.api.template.TemplatePayload;
 import io.flamingock.internal.common.core.recovery.action.ChangeAction;
 import io.flamingock.internal.core.task.loaded.AbstractTemplateLoadedChange;
 import io.flamingock.internal.util.FileUtil;
@@ -35,7 +36,7 @@ import java.util.Arrays;
  * @param <ROLLBACK> the rollback payload type
  * @param <T>        the type of template loaded change
  */
-public abstract class AbstractTemplateExecutableTask<CONFIG, APPLY, ROLLBACK,
+public abstract class AbstractTemplateExecutableTask<CONFIG, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload,
         T extends AbstractTemplateLoadedChange<CONFIG, APPLY, ROLLBACK>> extends ReflectionExecutableTask<T> {
     protected final Logger logger = FlamingockLoggerFactory.getLogger("TemplateTask");
 

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/SimpleTemplateExecutableTask.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/SimpleTemplateExecutableTask.java
@@ -16,6 +16,7 @@
 package io.flamingock.internal.core.task.executable;
 
 import io.flamingock.api.template.AbstractChangeTemplate;
+import io.flamingock.api.template.TemplatePayload;
 import io.flamingock.internal.common.core.error.ChangeExecutionException;
 import io.flamingock.internal.common.core.recovery.action.ChangeAction;
 import io.flamingock.internal.core.runtime.ExecutionRuntime;
@@ -31,7 +32,8 @@ import java.lang.reflect.Method;
  * @param <APPLY>    the apply payload type
  * @param <ROLLBACK> the rollback payload type
  */
-public class SimpleTemplateExecutableTask<CONFIG, APPLY, ROLLBACK>
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class SimpleTemplateExecutableTask<CONFIG, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload>
         extends AbstractTemplateExecutableTask<CONFIG, APPLY, ROLLBACK,
                 SimpleTemplateLoadedChange<CONFIG, APPLY, ROLLBACK>> {
 
@@ -56,10 +58,9 @@ public class SimpleTemplateExecutableTask<CONFIG, APPLY, ROLLBACK>
         executeInternal(executionRuntime, rollbackMethod);
     }
 
-    @SuppressWarnings("unchecked")
     protected void executeInternal(ExecutionRuntime executionRuntime, Method method) {
         try {
-            AbstractChangeTemplate<CONFIG, APPLY, ROLLBACK> instance = (AbstractChangeTemplate<CONFIG, APPLY, ROLLBACK>)
+            AbstractChangeTemplate instance = (AbstractChangeTemplate)
                             executionRuntime.getInstance(descriptor.getConstructor());
 
             instance.setTransactional(descriptor.isTransactional());

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/SteppableTemplateExecutableTask.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/SteppableTemplateExecutableTask.java
@@ -16,6 +16,7 @@
 package io.flamingock.internal.core.task.executable;
 
 import io.flamingock.api.template.AbstractChangeTemplate;
+import io.flamingock.api.template.TemplatePayload;
 import io.flamingock.api.template.TemplateStep;
 import io.flamingock.internal.common.core.error.ChangeExecutionException;
 import io.flamingock.internal.common.core.recovery.action.ChangeAction;
@@ -34,7 +35,8 @@ import java.util.List;
  * @param <APPLY>    the apply payload type
  * @param <ROLLBACK> the rollback payload type
  */
-public class SteppableTemplateExecutableTask<CONFIG, APPLY, ROLLBACK>
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class SteppableTemplateExecutableTask<CONFIG, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload>
         extends AbstractTemplateExecutableTask<CONFIG, APPLY, ROLLBACK,
         MultiStepTemplateLoadedChange<CONFIG, APPLY, ROLLBACK>> {
 
@@ -50,7 +52,7 @@ public class SteppableTemplateExecutableTask<CONFIG, APPLY, ROLLBACK>
 
     @Override
     public void apply(ExecutionRuntime executionRuntime) {
-        AbstractChangeTemplate<CONFIG, APPLY, ROLLBACK> instance = buildInstance(executionRuntime);
+        AbstractChangeTemplate instance = buildInstance(executionRuntime);
 
         try {
             List<TemplateStep<APPLY, ROLLBACK>> steps = descriptor.getSteps();
@@ -67,7 +69,7 @@ public class SteppableTemplateExecutableTask<CONFIG, APPLY, ROLLBACK>
 
     @Override
     public void rollback(ExecutionRuntime executionRuntime) {
-        AbstractChangeTemplate<CONFIG, APPLY, ROLLBACK> instance = buildInstance(executionRuntime);
+        AbstractChangeTemplate instance = buildInstance(executionRuntime);
 
         try {
             List<TemplateStep<APPLY, ROLLBACK>> steps = descriptor.getSteps();
@@ -88,14 +90,13 @@ public class SteppableTemplateExecutableTask<CONFIG, APPLY, ROLLBACK>
     }
 
     @NotNull
-    @SuppressWarnings("unchecked")
-    private AbstractChangeTemplate<CONFIG, APPLY, ROLLBACK> buildInstance(ExecutionRuntime executionRuntime) {
-        AbstractChangeTemplate<CONFIG, APPLY, ROLLBACK> instance;
+    private AbstractChangeTemplate buildInstance(ExecutionRuntime executionRuntime) {
+        AbstractChangeTemplate instance;
         try {
             logger.debug("Starting execution of change[{}] with template: {}", descriptor.getId(), descriptor.getTemplateClass());
             logger.debug("change[{}] transactional: {}", descriptor.getId(), descriptor.isTransactional());
 
-            instance = (AbstractChangeTemplate<CONFIG, APPLY, ROLLBACK>)
+            instance = (AbstractChangeTemplate)
                     executionRuntime.getInstance(descriptor.getConstructor());
 
             instance.setTransactional(descriptor.isTransactional());

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/AbstractTemplateLoadedChange.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/AbstractTemplateLoadedChange.java
@@ -18,6 +18,7 @@ package io.flamingock.internal.core.task.loaded;
 import io.flamingock.api.annotations.Apply;
 import io.flamingock.api.annotations.Rollback;
 import io.flamingock.api.template.ChangeTemplate;
+import io.flamingock.api.template.TemplatePayload;
 import io.flamingock.internal.common.core.error.validation.ValidationError;
 import io.flamingock.internal.common.core.task.RecoveryDescriptor;
 import io.flamingock.internal.common.core.task.TargetSystemDescriptor;
@@ -38,7 +39,7 @@ import java.util.Optional;
  * @param <APPLY>    the apply payload type
  * @param <ROLLBACK> the rollback payload type
  */
-public abstract class AbstractTemplateLoadedChange<CONFIG, APPLY, ROLLBACK> extends AbstractLoadedChange {
+public abstract class AbstractTemplateLoadedChange<CONFIG, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload> extends AbstractLoadedChange {
 
     private final List<String> profiles;
     private final CONFIG configurationPayload;

--- a/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/SimpleTemplateLoadedTaskBuilderTest.java
+++ b/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/SimpleTemplateLoadedTaskBuilderTest.java
@@ -22,6 +22,7 @@ import io.flamingock.internal.common.core.template.ChangeTemplateManager;
 import io.flamingock.api.annotations.ChangeTemplate;
 import io.flamingock.api.annotations.Rollback;
 import io.flamingock.api.template.AbstractChangeTemplate;
+import io.flamingock.api.template.wrappers.TemplateString;
 import io.flamingock.api.annotations.Apply;
 import io.flamingock.internal.core.pipeline.loaded.stage.StageValidationContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,7 +44,7 @@ class SimpleTemplateLoadedTaskBuilderTest {
 
     // Simple test template implementation using the annotation
     @ChangeTemplate(name = "test-change-template")
-    public static class TestChangeTemplate extends AbstractChangeTemplate<Object, Object, Object> {
+    public static class TestChangeTemplate extends AbstractChangeTemplate<Object, TemplateString, TemplateString> {
 
         public TestChangeTemplate() {
             super();

--- a/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/SteppableTemplateLoadedTaskBuilderTest.java
+++ b/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/SteppableTemplateLoadedTaskBuilderTest.java
@@ -20,6 +20,7 @@ import io.flamingock.api.annotations.ChangeTemplate;
 import io.flamingock.api.annotations.Rollback;
 import io.flamingock.api.template.AbstractChangeTemplate;
 import io.flamingock.api.template.TemplateStep;
+import io.flamingock.api.template.wrappers.TemplateString;
 import io.flamingock.internal.common.core.error.FlamingockException;
 import io.flamingock.internal.common.core.error.validation.ValidationError;
 import io.flamingock.internal.common.core.preview.TemplatePreviewChange;
@@ -49,7 +50,7 @@ class SteppableTemplateLoadedTaskBuilderTest {
 
     // Steppable test template implementation using the annotation
     @ChangeTemplate(name = "test-steppable-template", multiStep = true)
-    public static class TestSteppableTemplate extends AbstractChangeTemplate<Object, Object, Object> {
+    public static class TestSteppableTemplate extends AbstractChangeTemplate<Object, TemplateString, TemplateString> {
 
         public TestSteppableTemplate() {
             super();
@@ -67,7 +68,7 @@ class SteppableTemplateLoadedTaskBuilderTest {
 
     // Simple test template implementation
     @ChangeTemplate(name = "test-simple-template")
-    public static class TestSimpleTemplate extends AbstractChangeTemplate<Object, Object, Object> {
+    public static class TestSimpleTemplate extends AbstractChangeTemplate<Object, TemplateString, TemplateString> {
 
         public TestSimpleTemplate() {
             super();
@@ -258,10 +259,10 @@ class SteppableTemplateLoadedTaskBuilderTest {
             List<? extends TemplateStep<?, ?>> steps = steppableResult.getSteps();
             assertNotNull(steps);
             assertEquals(3, steps.size());
-            // Verify steps are preserved in order - payloads are now typed objects
-            assertEquals("createCollection", steps.get(0).getApplyPayload());
-            assertEquals("insertDocument", steps.get(1).getApplyPayload());
-            assertEquals("createIndex", steps.get(2).getApplyPayload());
+            // Verify steps are preserved in order - payloads are now typed TemplateString objects
+            assertEquals(new TemplateString("createCollection"), steps.get(0).getApplyPayload());
+            assertEquals(new TemplateString("insertDocument"), steps.get(1).getApplyPayload());
+            assertEquals(new TemplateString("createIndex"), steps.get(2).getApplyPayload());
         }
     }
 

--- a/platform-plugins/flamingock-springboot-integration/src/test/java/io/flamingock/springboot/SpringProfileFilterTemplateTaskTest.java
+++ b/platform-plugins/flamingock-springboot-integration/src/test/java/io/flamingock/springboot/SpringProfileFilterTemplateTaskTest.java
@@ -20,6 +20,7 @@ import io.flamingock.api.annotations.ChangeTemplate;
 import io.flamingock.internal.common.core.template.ChangeTemplateFileContent;
 import io.flamingock.internal.common.core.task.RecoveryDescriptor;
 import io.flamingock.api.template.AbstractChangeTemplate;
+import io.flamingock.api.template.wrappers.TemplateString;
 import io.flamingock.internal.common.core.template.ChangeTemplateManager;
 import io.flamingock.internal.common.core.preview.TemplatePreviewChange;
 import io.flamingock.internal.common.core.preview.builder.PreviewTaskBuilder;
@@ -128,7 +129,7 @@ class SpringProfileFilterTemplateTaskTest {
     }
 
     @ChangeTemplate(name = "template-simulate")
-    public static class TemplateSimulate extends AbstractChangeTemplate<Void, Object, Object> {
+    public static class TemplateSimulate extends AbstractChangeTemplate<Void, TemplateString, TemplateString> {
         public TemplateSimulate() {
             super();
         }


### PR DESCRIPTION
  Template payload types (**APPLY** and **ROLLBACK**) are now required to implement
  the TemplatePayload interface, which provides a validate() method called
  at pipeline load time — before any change executes.

  Public API:
  - **TemplatePayload** interface with validate() returning validation errors
  - **TemplatePayloadValidationError** for field-level and general error reporting
  - **TemplateString** wrapper for String-based payloads (e.g. raw SQL)
  - **ChangeTemplate** and **AbstractChangeTemplate** now enforce
    **APPLY**/**ROLLBACK** extends TemplatePayload bounds

  Internal type alignment:
  - **AbstractTemplateLoadedChange**, **SimpleTemplateLoadedChange**, and
    **MultiStepTemplateLoadedChange** propagate **TemplatePayload** bounds,
    enabling direct validate() calls without instanceof checks or casts
  - **AbstractTemplateExecutableTask** and its subclasses propagate bounds,
    removing explicit (**TemplatePayload**) casts on **setApplyPayload**/**setRollbackPayload**
  - **TemplateLoadedTaskBuilder** remains the sole raw-type boundary where
    runtime reflection constructs the typed hierarchy
  - FileUtil extended with scalar-to-wrapper conversion for SnakeYAML
    deserialization of TemplateString from plain YAML strings