### PR TITLE
feat(templates): extend TemplatePayload bound to CONFIG type parameter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -511,3 +511,24 @@ See `docs/TEMPLATES_EVOLUTION_PROPOSALS.md` for comprehensive proposals includin
 - Explicit dependencies (`depends_on`)
 - Policy as Code
 - And more...
+
+## Commit Message Convention
+
+All commits must follow [Conventional Commits](https://www.conventionalcommits.org/) with a well-structured body suitable for changelog extraction from `git log`.
+
+### Format
+
+```
+<type>(<scope>): <concise imperative summary>
+
+<body: precise explanation of what changed and why, using markdown formatting>
+```
+
+### Rules
+
+- **Title**: imperative mood, lowercase, no period, under 72 characters
+- **Type**: `feat`, `fix`, `refactor`, `chore`, `ci`, `docs`, `test`
+- **Scope**: optional but encouraged (e.g., `templates`, `core`, `cli`)
+- **Body**: required for `feat` and `fix`. Explains *what* changed and *why* at a level suitable for a professional changelog. Use bullet points, bold for class/concept names, and keep it concise — no filler, no redundancy
+- **No PR number** in the title when committing locally (GitHub adds it on merge)
+- The body is the source of truth for the changelog — write it as if a technical user will read it to understand the release

--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/template/AbstractChangeTemplate.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/template/AbstractChangeTemplate.java
@@ -34,12 +34,12 @@ import java.util.Set;
  *
  * <p>Use {@code @ChangeTemplate(steppable = true)} for steppable templates with multiple steps.
  *
- * @param <SHARED_CONFIGURATION_FIELD> shared configuration type (use {@code Void} if none)
+ * @param <SHARED_CONFIGURATION_FIELD> shared configuration type (use {@code TemplateVoid} if none)
  * @param <APPLY_FIELD> apply payload type
  * @param <ROLLBACK_FIELD> rollback payload type
  * @see io.flamingock.api.annotations.ChangeTemplate
  */
-public abstract class AbstractChangeTemplate<SHARED_CONFIGURATION_FIELD, APPLY_FIELD extends TemplatePayload, ROLLBACK_FIELD extends TemplatePayload> implements ChangeTemplate<SHARED_CONFIGURATION_FIELD, APPLY_FIELD, ROLLBACK_FIELD> {
+public abstract class AbstractChangeTemplate<SHARED_CONFIGURATION_FIELD extends TemplatePayload, APPLY_FIELD extends TemplatePayload, ROLLBACK_FIELD extends TemplatePayload> implements ChangeTemplate<SHARED_CONFIGURATION_FIELD, APPLY_FIELD, ROLLBACK_FIELD> {
 
     private final Class<SHARED_CONFIGURATION_FIELD> configurationClass;
     private final Class<APPLY_FIELD> applyPayloadClass;

--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/template/ChangeTemplate.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/template/ChangeTemplate.java
@@ -22,13 +22,13 @@ package io.flamingock.api.template;
  * by extending {@link AbstractChangeTemplate} and annotating with
  * {@link io.flamingock.api.annotations.ChangeTemplate}.
  *
- * @param <SHARED_CONFIG_FIELD> shared configuration type (use {@code Void} if none)
+ * @param <SHARED_CONFIG_FIELD> shared configuration type (use {@code TemplateVoid} if none)
  * @param <APPLY_FIELD> apply payload type parsed from YAML
  * @param <ROLLBACK_FIELD> rollback payload type parsed from YAML
  * @see AbstractChangeTemplate
  * @see io.flamingock.api.annotations.ChangeTemplate
  */
-public interface ChangeTemplate<SHARED_CONFIG_FIELD, APPLY_FIELD extends TemplatePayload, ROLLBACK_FIELD extends TemplatePayload> extends ReflectionMetadataProvider {
+public interface ChangeTemplate<SHARED_CONFIG_FIELD extends TemplatePayload, APPLY_FIELD extends TemplatePayload, ROLLBACK_FIELD extends TemplatePayload> extends ReflectionMetadataProvider {
 
     void setChangeId(String changeId);
 

--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/template/wrappers/TemplateVoid.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/template/wrappers/TemplateVoid.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Flamingock (https://www.flamingock.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.flamingock.api.template.wrappers;
+
+import io.flamingock.api.template.TemplatePayload;
+import io.flamingock.api.template.TemplatePayloadValidationError;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@link TemplatePayload} sentinel representing "no configuration needed".
+ *
+ * <p>Replaces {@code Void} as the CONFIG type parameter in templates that
+ * have no shared configuration. Unlike {@code Void}, this class implements
+ * {@code TemplatePayload}, satisfying the {@code CONFIG extends TemplatePayload}
+ * bound on the template system.
+ */
+public class TemplateVoid implements TemplatePayload {
+
+    @Override
+    public List<TemplatePayloadValidationError> validate() {
+        return Collections.emptyList();
+    }
+}

--- a/core/flamingock-core-api/src/test/java/io/flamingock/api/template/AbstractChangeTemplateReflectiveClassesTest.java
+++ b/core/flamingock-core-api/src/test/java/io/flamingock/api/template/AbstractChangeTemplateReflectiveClassesTest.java
@@ -19,6 +19,7 @@ import io.flamingock.api.annotations.Apply;
 import io.flamingock.api.annotations.ChangeTemplate;
 import io.flamingock.api.annotations.Rollback;
 import io.flamingock.api.template.wrappers.TemplateString;
+import io.flamingock.api.template.wrappers.TemplateVoid;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -31,8 +32,13 @@ import static org.junit.jupiter.api.Assertions.*;
 class AbstractChangeTemplateReflectiveClassesTest {
 
     // Simple test configuration class
-    public static class TestConfig {
+    public static class TestConfig implements TemplatePayload {
         public String configValue;
+
+        @Override
+        public List<TemplatePayloadValidationError> validate() {
+            return Collections.emptyList();
+        }
     }
 
     // Simple test apply payload class
@@ -103,10 +109,10 @@ class AbstractChangeTemplateReflectiveClassesTest {
         }
     }
 
-    // Test template with Void configuration
+    // Test template with TemplateVoid configuration
     @ChangeTemplate(name = "test-template-with-void-config")
     public static class TestTemplateWithVoidConfig
-            extends AbstractChangeTemplate<Void, TemplateString, TemplateString> {
+            extends AbstractChangeTemplate<TemplateVoid, TemplateString, TemplateString> {
 
         public TestTemplateWithVoidConfig() {
             super();
@@ -196,14 +202,14 @@ class AbstractChangeTemplateReflectiveClassesTest {
     }
 
     @Test
-    @DisplayName("getReflectiveClasses with Void configuration should include Void class")
-    void getReflectiveClassesWithVoidConfigShouldIncludeVoidClass() {
+    @DisplayName("getReflectiveClasses with TemplateVoid configuration should include TemplateVoid class")
+    void getReflectiveClassesWithVoidConfigShouldIncludeTemplateVoidClass() {
         TestTemplateWithVoidConfig template = new TestTemplateWithVoidConfig();
 
         Collection<Class<?>> reflectiveClasses = template.getReflectiveClasses();
 
-        assertTrue(reflectiveClasses.contains(Void.class),
-                "Should contain Void class for configuration");
+        assertTrue(reflectiveClasses.contains(TemplateVoid.class),
+                "Should contain TemplateVoid class for configuration");
         assertTrue(reflectiveClasses.contains(TemplateString.class),
                 "Should contain TemplateString class for apply/rollback payloads");
     }

--- a/core/flamingock-core-commons/src/test/java/io/flamingock/internal/common/core/template/ChangeTemplateManagerTest.java
+++ b/core/flamingock-core-commons/src/test/java/io/flamingock/internal/common/core/template/ChangeTemplateManagerTest.java
@@ -20,6 +20,7 @@ import io.flamingock.api.annotations.ChangeTemplate;
 import io.flamingock.api.annotations.Rollback;
 import io.flamingock.api.template.AbstractChangeTemplate;
 import io.flamingock.api.template.wrappers.TemplateString;
+import io.flamingock.api.template.wrappers.TemplateVoid;
 import io.flamingock.internal.common.core.error.FlamingockException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class ChangeTemplateManagerTest {
 
     @ChangeTemplate(name = "annotated-simple-template")
-    public static class AnnotatedSimpleTemplate extends AbstractChangeTemplate<Void, TemplateString, TemplateString> {
+    public static class AnnotatedSimpleTemplate extends AbstractChangeTemplate<TemplateVoid, TemplateString, TemplateString> {
         public AnnotatedSimpleTemplate() {
             super();
         }
@@ -46,7 +47,7 @@ class ChangeTemplateManagerTest {
     }
 
     @ChangeTemplate(name = "annotated-steppable-template", multiStep = true)
-    public static class AnnotatedSteppableTemplate extends AbstractChangeTemplate<Void, TemplateString, TemplateString> {
+    public static class AnnotatedSteppableTemplate extends AbstractChangeTemplate<TemplateVoid, TemplateString, TemplateString> {
         public AnnotatedSteppableTemplate() {
             super();
         }
@@ -60,7 +61,7 @@ class ChangeTemplateManagerTest {
         }
     }
 
-    public static class UnannotatedTemplate extends AbstractChangeTemplate<Void, TemplateString, TemplateString> {
+    public static class UnannotatedTemplate extends AbstractChangeTemplate<TemplateVoid, TemplateString, TemplateString> {
         public UnannotatedTemplate() {
             super();
         }
@@ -114,7 +115,7 @@ class ChangeTemplateManagerTest {
     }
 
     @ChangeTemplate(name = "template-rollback-not-required", rollbackPayloadRequired = false)
-    public static class TemplateWithRollbackNotRequired extends AbstractChangeTemplate<Void, TemplateString, TemplateString> {
+    public static class TemplateWithRollbackNotRequired extends AbstractChangeTemplate<TemplateVoid, TemplateString, TemplateString> {
         public TemplateWithRollbackNotRequired() {
             super();
         }
@@ -141,7 +142,7 @@ class ChangeTemplateManagerTest {
     }
 
     @ChangeTemplate(name = "template-without-rollback")
-    public static class TemplateWithoutRollback extends AbstractChangeTemplate<Void, TemplateString, TemplateString> {
+    public static class TemplateWithoutRollback extends AbstractChangeTemplate<TemplateVoid, TemplateString, TemplateString> {
         public TemplateWithoutRollback() {
             super();
         }

--- a/core/flamingock-core-commons/src/test/java/io/flamingock/internal/common/core/template/TemplateValidatorTest.java
+++ b/core/flamingock-core-commons/src/test/java/io/flamingock/internal/common/core/template/TemplateValidatorTest.java
@@ -20,6 +20,7 @@ import io.flamingock.api.annotations.ChangeTemplate;
 import io.flamingock.api.annotations.Rollback;
 import io.flamingock.api.template.AbstractChangeTemplate;
 import io.flamingock.api.template.wrappers.TemplateString;
+import io.flamingock.api.template.wrappers.TemplateVoid;
 import io.flamingock.internal.common.core.error.validation.ValidationResult;
 import io.flamingock.internal.common.core.preview.TemplatePreviewChange;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,7 +42,7 @@ class TemplateValidatorTest {
 
     // Test template with @ChangeTemplate (simple template)
     @ChangeTemplate(name = "test-simple-template")
-    public static class TestSimpleTemplate extends AbstractChangeTemplate<Void, TemplateString, TemplateString> {
+    public static class TestSimpleTemplate extends AbstractChangeTemplate<TemplateVoid, TemplateString, TemplateString> {
         public TestSimpleTemplate() {
             super();
         }
@@ -58,7 +59,7 @@ class TemplateValidatorTest {
 
     // Test template with @ChangeTemplate(multiStep = true)
     @ChangeTemplate(name = "test-steppable-template", multiStep = true)
-    public static class TestSteppableTemplate extends AbstractChangeTemplate<Void, TemplateString, TemplateString> {
+    public static class TestSteppableTemplate extends AbstractChangeTemplate<TemplateVoid, TemplateString, TemplateString> {
         public TestSteppableTemplate() {
             super();
         }

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/AbstractTemplateExecutableTask.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/AbstractTemplateExecutableTask.java
@@ -17,9 +17,9 @@ package io.flamingock.internal.core.task.executable;
 
 import io.flamingock.api.template.ChangeTemplate;
 import io.flamingock.api.template.TemplatePayload;
+import io.flamingock.api.template.wrappers.TemplateVoid;
 import io.flamingock.internal.common.core.recovery.action.ChangeAction;
 import io.flamingock.internal.core.task.loaded.AbstractTemplateLoadedChange;
-import io.flamingock.internal.util.FileUtil;
 import io.flamingock.internal.util.log.FlamingockLoggerFactory;
 import org.slf4j.Logger;
 
@@ -36,7 +36,7 @@ import java.util.Arrays;
  * @param <ROLLBACK> the rollback payload type
  * @param <T>        the type of template loaded change
  */
-public abstract class AbstractTemplateExecutableTask<CONFIG, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload,
+public abstract class AbstractTemplateExecutableTask<CONFIG extends TemplatePayload, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload,
         T extends AbstractTemplateLoadedChange<CONFIG, APPLY, ROLLBACK>> extends ReflectionExecutableTask<T> {
     protected final Logger logger = FlamingockLoggerFactory.getLogger("TemplateTask");
 
@@ -52,9 +52,9 @@ public abstract class AbstractTemplateExecutableTask<CONFIG, APPLY extends Templ
         Class<CONFIG> parameterClass = instance.getConfigurationClass();
         CONFIG data = descriptor.getConfigurationPayload();
 
-        if (data != null && Void.class != parameterClass) {
-            instance.setConfiguration(FileUtil.convertToType(parameterClass, data));
-        } else if (Void.class != parameterClass) {
+        if (data != null && TemplateVoid.class != parameterClass) {
+            instance.setConfiguration(data);
+        } else if (TemplateVoid.class != parameterClass) {
             logger.warn("No 'Configuration' section provided for template-based change[{}] of type[{}]",
                     descriptor.getId(), descriptor.getTemplateClass().getName());
         }

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/SimpleTemplateExecutableTask.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/SimpleTemplateExecutableTask.java
@@ -33,7 +33,7 @@ import java.lang.reflect.Method;
  * @param <ROLLBACK> the rollback payload type
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class SimpleTemplateExecutableTask<CONFIG, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload>
+public class SimpleTemplateExecutableTask<CONFIG extends TemplatePayload, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload>
         extends AbstractTemplateExecutableTask<CONFIG, APPLY, ROLLBACK,
                 SimpleTemplateLoadedChange<CONFIG, APPLY, ROLLBACK>> {
 

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/SteppableTemplateExecutableTask.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/SteppableTemplateExecutableTask.java
@@ -36,7 +36,7 @@ import java.util.List;
  * @param <ROLLBACK> the rollback payload type
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class SteppableTemplateExecutableTask<CONFIG, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload>
+public class SteppableTemplateExecutableTask<CONFIG extends TemplatePayload, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload>
         extends AbstractTemplateExecutableTask<CONFIG, APPLY, ROLLBACK,
         MultiStepTemplateLoadedChange<CONFIG, APPLY, ROLLBACK>> {
 

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/AbstractTemplateLoadedChange.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/AbstractTemplateLoadedChange.java
@@ -39,7 +39,7 @@ import java.util.Optional;
  * @param <APPLY>    the apply payload type
  * @param <ROLLBACK> the rollback payload type
  */
-public abstract class AbstractTemplateLoadedChange<CONFIG, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload> extends AbstractLoadedChange {
+public abstract class AbstractTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload> extends AbstractLoadedChange {
 
     private final List<String> profiles;
     private final CONFIG configurationPayload;

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/MultiStepTemplateLoadedChange.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/MultiStepTemplateLoadedChange.java
@@ -39,7 +39,7 @@ import java.util.List;
  * @param <APPLY>    the apply payload type
  * @param <ROLLBACK> the rollback payload type
  */
-public class MultiStepTemplateLoadedChange<CONFIG, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload>
+public class MultiStepTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload>
         extends AbstractTemplateLoadedChange<CONFIG, APPLY, ROLLBACK> {
 
     private final List<TemplateStep<APPLY, ROLLBACK>> steps;
@@ -69,6 +69,19 @@ public class MultiStepTemplateLoadedChange<CONFIG, APPLY extends TemplatePayload
 
     @Override
     protected List<ValidationError> validateConfigurationPayload() {
+        CONFIG config = getConfigurationPayload();
+        if (config != null) {
+            List<TemplatePayloadValidationError> payloadErrors = config.validate();
+            if (!payloadErrors.isEmpty()) {
+                List<ValidationError> errors = new ArrayList<>();
+                for (TemplatePayloadValidationError e : payloadErrors) {
+                    errors.add(new ValidationError(
+                            String.format("Template '%s' configuration payload: %s", getSource(), e.getFormattedMessage()),
+                            getId(), "change"));
+                }
+                return errors;
+            }
+        }
         return Collections.emptyList();
     }
 

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/SimpleTemplateLoadedChange.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/SimpleTemplateLoadedChange.java
@@ -38,7 +38,7 @@ import java.util.List;
  * @param <APPLY>    the apply payload type
  * @param <ROLLBACK> the rollback payload type
  */
-public class SimpleTemplateLoadedChange<CONFIG, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload>
+public class SimpleTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload>
         extends AbstractTemplateLoadedChange<CONFIG, APPLY, ROLLBACK> {
 
     // Already converted to typed payload (no longer raw Object from YAML)
@@ -80,6 +80,19 @@ public class SimpleTemplateLoadedChange<CONFIG, APPLY extends TemplatePayload, R
 
     @Override
     protected List<ValidationError> validateConfigurationPayload() {
+        CONFIG config = getConfigurationPayload();
+        if (config != null) {
+            List<TemplatePayloadValidationError> payloadErrors = config.validate();
+            if (!payloadErrors.isEmpty()) {
+                List<ValidationError> errors = new ArrayList<>();
+                for (TemplatePayloadValidationError e : payloadErrors) {
+                    errors.add(new ValidationError(
+                            String.format("Template '%s' configuration payload: %s", getSource(), e.getFormattedMessage()),
+                            getId(), "change"));
+                }
+                return errors;
+            }
+        }
         return Collections.emptyList();
     }
 

--- a/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/executable/SteppableTemplateExecutableTaskTest.java
+++ b/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/executable/SteppableTemplateExecutableTaskTest.java
@@ -21,6 +21,7 @@ import io.flamingock.api.annotations.Rollback;
 import io.flamingock.api.template.AbstractChangeTemplate;
 import io.flamingock.api.template.TemplateStep;
 import io.flamingock.api.template.wrappers.TemplateString;
+import io.flamingock.api.template.wrappers.TemplateVoid;
 import io.flamingock.internal.common.core.error.ChangeExecutionException;
 import io.flamingock.internal.common.core.error.FlamingockException;
 import io.flamingock.internal.common.core.recovery.action.ChangeAction;
@@ -45,7 +46,7 @@ import static org.mockito.Mockito.*;
 class SteppableTemplateExecutableTaskTest {
 
     private ExecutionRuntime mockRuntime;
-    private MultiStepTemplateLoadedChange<Void, TemplateString, TemplateString> mockDescriptor;
+    private MultiStepTemplateLoadedChange<TemplateVoid, TemplateString, TemplateString> mockDescriptor;
     private Method applyMethod;
     private Method rollbackMethod;
 
@@ -60,7 +61,7 @@ class SteppableTemplateExecutableTaskTest {
      * Test template that tracks apply and rollback invocations.
      */
     @ChangeTemplate(name = "test-steppable-template", multiStep = true)
-    public static class TestSteppableTemplate extends AbstractChangeTemplate<Void, TemplateString, TemplateString> {
+    public static class TestSteppableTemplate extends AbstractChangeTemplate<TemplateVoid, TemplateString, TemplateString> {
 
         public TestSteppableTemplate() {
             super();
@@ -87,7 +88,7 @@ class SteppableTemplateExecutableTaskTest {
      * Test template used to simulate null rollback method at executable level.
      */
     @ChangeTemplate(name = "test-template-null-rollback-method", multiStep = true)
-    public static class TestTemplateWithNullRollbackMethod extends AbstractChangeTemplate<Void, TemplateString, TemplateString> {
+    public static class TestTemplateWithNullRollbackMethod extends AbstractChangeTemplate<TemplateVoid, TemplateString, TemplateString> {
 
         public TestTemplateWithNullRollbackMethod() {
             super();
@@ -163,7 +164,7 @@ class SteppableTemplateExecutableTaskTest {
         );
         when(mockDescriptor.getSteps()).thenReturn(steps);
 
-        SteppableTemplateExecutableTask<Void, TemplateString, TemplateString> task = new SteppableTemplateExecutableTask<>(
+        SteppableTemplateExecutableTask<TemplateVoid, TemplateString, TemplateString> task = new SteppableTemplateExecutableTask<>(
                 "test-stage",
                 mockDescriptor,
                 ChangeAction.APPLY,
@@ -195,7 +196,7 @@ class SteppableTemplateExecutableTaskTest {
         );
         when(mockDescriptor.getSteps()).thenReturn(steps);
 
-        SteppableTemplateExecutableTask<Void, TemplateString, TemplateString> task = new SteppableTemplateExecutableTask<>(
+        SteppableTemplateExecutableTask<TemplateVoid, TemplateString, TemplateString> task = new SteppableTemplateExecutableTask<>(
                 "test-stage",
                 mockDescriptor,
                 ChangeAction.APPLY,
@@ -232,7 +233,7 @@ class SteppableTemplateExecutableTaskTest {
         );
         when(mockDescriptor.getSteps()).thenReturn(steps);
 
-        SteppableTemplateExecutableTask<Void, TemplateString, TemplateString> task = new SteppableTemplateExecutableTask<>(
+        SteppableTemplateExecutableTask<TemplateVoid, TemplateString, TemplateString> task = new SteppableTemplateExecutableTask<>(
                 "test-stage",
                 mockDescriptor,
                 ChangeAction.APPLY,
@@ -263,7 +264,7 @@ class SteppableTemplateExecutableTaskTest {
         );
         when(mockDescriptor.getSteps()).thenReturn(steps);
 
-        SteppableTemplateExecutableTask<Void, TemplateString, TemplateString> task = new SteppableTemplateExecutableTask<>(
+        SteppableTemplateExecutableTask<TemplateVoid, TemplateString, TemplateString> task = new SteppableTemplateExecutableTask<>(
                 "test-stage",
                 mockDescriptor,
                 ChangeAction.APPLY,
@@ -298,7 +299,7 @@ class SteppableTemplateExecutableTaskTest {
         );
         when(mockDescriptor.getSteps()).thenReturn(steps);
 
-        SteppableTemplateExecutableTask<Void, TemplateString, TemplateString> task = new SteppableTemplateExecutableTask<>(
+        SteppableTemplateExecutableTask<TemplateVoid, TemplateString, TemplateString> task = new SteppableTemplateExecutableTask<>(
                 "test-stage",
                 mockDescriptor,
                 ChangeAction.APPLY,
@@ -329,7 +330,7 @@ class SteppableTemplateExecutableTaskTest {
         List<TemplateStep<TemplateString, TemplateString>> emptySteps = Collections.emptyList();
         when(mockDescriptor.getSteps()).thenReturn(emptySteps);
 
-        SteppableTemplateExecutableTask<Void, TemplateString, TemplateString> task = new SteppableTemplateExecutableTask<>(
+        SteppableTemplateExecutableTask<TemplateVoid, TemplateString, TemplateString> task = new SteppableTemplateExecutableTask<>(
                 "test-stage",
                 mockDescriptor,
                 ChangeAction.APPLY,
@@ -366,7 +367,7 @@ class SteppableTemplateExecutableTaskTest {
         );
         when(mockDescriptor.getSteps()).thenReturn(steps);
 
-        SteppableTemplateExecutableTask<Void, TemplateString, TemplateString> task = new SteppableTemplateExecutableTask<>(
+        SteppableTemplateExecutableTask<TemplateVoid, TemplateString, TemplateString> task = new SteppableTemplateExecutableTask<>(
                 "test-stage",
                 mockDescriptor,
                 ChangeAction.APPLY,
@@ -395,7 +396,7 @@ class SteppableTemplateExecutableTaskTest {
         );
         when(mockDescriptor.getSteps()).thenReturn(steps);
 
-        SteppableTemplateExecutableTask<Void, TemplateString, TemplateString> task = new SteppableTemplateExecutableTask<>(
+        SteppableTemplateExecutableTask<TemplateVoid, TemplateString, TemplateString> task = new SteppableTemplateExecutableTask<>(
                 "test-stage",
                 mockDescriptor,
                 ChangeAction.APPLY,
@@ -427,7 +428,7 @@ class SteppableTemplateExecutableTaskTest {
         );
         when(mockDescriptor.getSteps()).thenReturn(steps);
 
-        SteppableTemplateExecutableTask<Void, TemplateString, TemplateString> task = new SteppableTemplateExecutableTask<>(
+        SteppableTemplateExecutableTask<TemplateVoid, TemplateString, TemplateString> task = new SteppableTemplateExecutableTask<>(
                 "test-stage",
                 mockDescriptor,
                 ChangeAction.APPLY,
@@ -463,7 +464,7 @@ class SteppableTemplateExecutableTaskTest {
         );
         when(mockDescriptor.getSteps()).thenReturn(steps);
 
-        SteppableTemplateExecutableTask<Void, TemplateString, TemplateString> task = new SteppableTemplateExecutableTask<>(
+        SteppableTemplateExecutableTask<TemplateVoid, TemplateString, TemplateString> task = new SteppableTemplateExecutableTask<>(
                 "test-stage",
                 mockDescriptor,
                 ChangeAction.APPLY,

--- a/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/SimpleTemplateLoadedTaskBuilderTest.java
+++ b/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/SimpleTemplateLoadedTaskBuilderTest.java
@@ -23,6 +23,7 @@ import io.flamingock.api.annotations.ChangeTemplate;
 import io.flamingock.api.annotations.Rollback;
 import io.flamingock.api.template.AbstractChangeTemplate;
 import io.flamingock.api.template.wrappers.TemplateString;
+import io.flamingock.api.template.wrappers.TemplateVoid;
 import io.flamingock.api.annotations.Apply;
 import io.flamingock.internal.core.pipeline.loaded.stage.StageValidationContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,7 +45,7 @@ class SimpleTemplateLoadedTaskBuilderTest {
 
     // Simple test template implementation using the annotation
     @ChangeTemplate(name = "test-change-template")
-    public static class TestChangeTemplate extends AbstractChangeTemplate<Object, TemplateString, TemplateString> {
+    public static class TestChangeTemplate extends AbstractChangeTemplate<TemplateVoid, TemplateString, TemplateString> {
 
         public TestChangeTemplate() {
             super();
@@ -80,7 +81,7 @@ class SimpleTemplateLoadedTaskBuilderTest {
                     .setRunAlways(false)
                     .setTransactional(true)
                     .setSystem(false)
-                    .setConfiguration("testConfig")
+                    .setConfiguration(null)
                     .setApplyPayload("applyPayload")
                     .setRollbackPayload("rollbackPayload");
             builder.setProfiles(Arrays.asList("test"));
@@ -116,7 +117,7 @@ class SimpleTemplateLoadedTaskBuilderTest {
                     .setRunAlways(false)
                     .setTransactional(true)
                     .setSystem(false)
-                    .setConfiguration("testConfig")
+                    .setConfiguration(null)
                     .setApplyPayload("applyPayload")
                     .setRollbackPayload("rollbackPayload");
             builder.setProfiles(Arrays.asList("test"));
@@ -148,7 +149,7 @@ class SimpleTemplateLoadedTaskBuilderTest {
             builder.setProfiles(Arrays.asList("test"));
             builder.setTransactional(true)
                     .setSystem(false)
-                    .setConfiguration("testConfig")
+                    .setConfiguration(null)
                     .setApplyPayload("applyPayload")
                     .setRollbackPayload("rollbackPayload");
 

--- a/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/SteppableTemplateLoadedTaskBuilderTest.java
+++ b/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/SteppableTemplateLoadedTaskBuilderTest.java
@@ -21,6 +21,7 @@ import io.flamingock.api.annotations.Rollback;
 import io.flamingock.api.template.AbstractChangeTemplate;
 import io.flamingock.api.template.TemplateStep;
 import io.flamingock.api.template.wrappers.TemplateString;
+import io.flamingock.api.template.wrappers.TemplateVoid;
 import io.flamingock.internal.common.core.error.FlamingockException;
 import io.flamingock.internal.common.core.error.validation.ValidationError;
 import io.flamingock.internal.common.core.preview.TemplatePreviewChange;
@@ -50,7 +51,7 @@ class SteppableTemplateLoadedTaskBuilderTest {
 
     // Steppable test template implementation using the annotation
     @ChangeTemplate(name = "test-steppable-template", multiStep = true)
-    public static class TestSteppableTemplate extends AbstractChangeTemplate<Object, TemplateString, TemplateString> {
+    public static class TestSteppableTemplate extends AbstractChangeTemplate<TemplateVoid, TemplateString, TemplateString> {
 
         public TestSteppableTemplate() {
             super();
@@ -68,7 +69,7 @@ class SteppableTemplateLoadedTaskBuilderTest {
 
     // Simple test template implementation
     @ChangeTemplate(name = "test-simple-template")
-    public static class TestSimpleTemplate extends AbstractChangeTemplate<Object, TemplateString, TemplateString> {
+    public static class TestSimpleTemplate extends AbstractChangeTemplate<TemplateVoid, TemplateString, TemplateString> {
 
         public TestSimpleTemplate() {
             super();
@@ -145,7 +146,7 @@ class SteppableTemplateLoadedTaskBuilderTest {
                     .setRunAlways(false)
                     .setTransactional(true)
                     .setSystem(false)
-                    .setConfiguration(new Object())
+                    .setConfiguration(null)
                     .setSteps(rawSteps);
             builder.setProfiles(Arrays.asList("test"));
 
@@ -179,7 +180,7 @@ class SteppableTemplateLoadedTaskBuilderTest {
                     .setRunAlways(false)
                     .setTransactional(true)
                     .setSystem(false)
-                    .setConfiguration(new Object())
+                    .setConfiguration(null)
                     .setSteps(rawSteps);
             builder.setProfiles(Arrays.asList("test"));
 

--- a/platform-plugins/flamingock-springboot-integration/src/test/java/io/flamingock/springboot/SpringProfileFilterTemplateTaskTest.java
+++ b/platform-plugins/flamingock-springboot-integration/src/test/java/io/flamingock/springboot/SpringProfileFilterTemplateTaskTest.java
@@ -21,6 +21,7 @@ import io.flamingock.internal.common.core.template.ChangeTemplateFileContent;
 import io.flamingock.internal.common.core.task.RecoveryDescriptor;
 import io.flamingock.api.template.AbstractChangeTemplate;
 import io.flamingock.api.template.wrappers.TemplateString;
+import io.flamingock.api.template.wrappers.TemplateVoid;
 import io.flamingock.internal.common.core.template.ChangeTemplateManager;
 import io.flamingock.internal.common.core.preview.TemplatePreviewChange;
 import io.flamingock.internal.common.core.preview.builder.PreviewTaskBuilder;
@@ -129,7 +130,7 @@ class SpringProfileFilterTemplateTaskTest {
     }
 
     @ChangeTemplate(name = "template-simulate")
-    public static class TemplateSimulate extends AbstractChangeTemplate<Void, TemplateString, TemplateString> {
+    public static class TemplateSimulate extends AbstractChangeTemplate<TemplateVoid, TemplateString, TemplateString> {
         public TemplateSimulate() {
             super();
         }


### PR DESCRIPTION
The APPLY and ROLLBACK type parameters already enforced `extends TemplatePayload`,
but CONFIG remained unbounded — preventing load-time validation of configuration
payloads. This change completes the contract across all three template generics.

Public API:
- **ChangeTemplate** and **AbstractChangeTemplate** now require
  `CONFIG extends TemplatePayload`
- **TemplateVoid** sentinel replaces `Void` for templates with no configuration,
  implementing TemplatePayload with a no-op validate()

Load-time CONFIG conversion:
- **TemplateLoadedTaskBuilder** now converts CONFIG from raw YAML data to typed
  TemplatePayload at load time, consistent with APPLY/ROLLBACK conversion
- Dead `Void.class` guard checks removed from convertPayloads() and convertSteps()

Validation:
- **SimpleTemplateLoadedChange** and **MultiStepTemplateLoadedChange** implement
  validateConfigurationPayload(), calling config.validate() at pipeline load time

Executable task simplification:
- **AbstractTemplateExecutableTask.setConfigurationData()** no longer re-converts
  the already-typed config; uses TemplateVoid.class sentinel instead of Void.class

