### PR TITLE
feat(templates): add TemplateValidationContext to TemplatePayload.validate()

### DIFF
--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/template/TemplatePayload.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/template/TemplatePayload.java
@@ -26,9 +26,11 @@ import java.util.List;
 public interface TemplatePayload {
 
     /**
-     * Validates this payload and returns any errors found.
+     * Validates this payload using the supplied change-level context
+     * and returns any errors found.
      *
+     * @param context change-level metadata available during validation
      * @return list of validation errors, empty if payload is valid
      */
-    List<TemplatePayloadValidationError> validate();
+    List<TemplatePayloadValidationError> validate(TemplateValidationContext context);
 }

--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/template/TemplateValidationContext.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/template/TemplateValidationContext.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Flamingock (https://www.flamingock.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.flamingock.api.template;
+
+/**
+ * Context provided to {@link TemplatePayload#validate(TemplateValidationContext)}
+ * so payload validation can access change-level metadata.
+ *
+ * <p><b>Binary-compatibility contract:</b> new fields are added as
+ * getter/setter pairs with sensible defaults.  Older template payloads
+ * that ignore the new fields continue to work unchanged.
+ *
+ * <p>Current fields:
+ * <ul>
+ *   <li>{@code transactional} (default {@code false}) — whether the
+ *       enclosing change is declared transactional.</li>
+ * </ul>
+ */
+public class TemplateValidationContext {
+
+    private boolean transactional;
+
+    /**
+     * Creates a context with all fields set to their defaults.
+     */
+    public TemplateValidationContext() {
+    }
+
+    /**
+     * Returns whether the enclosing change is declared transactional.
+     *
+     * @return {@code true} if the change is transactional, {@code false} otherwise
+     */
+    public boolean isTransactional() {
+        return transactional;
+    }
+
+    /**
+     * Sets whether the enclosing change is declared transactional.
+     *
+     * @param transactional {@code true} if the change is transactional
+     */
+    public void setTransactional(boolean transactional) {
+        this.transactional = transactional;
+    }
+}

--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/template/wrappers/TemplateString.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/template/wrappers/TemplateString.java
@@ -17,6 +17,7 @@ package io.flamingock.api.template.wrappers;
 
 import io.flamingock.api.template.TemplatePayload;
 import io.flamingock.api.template.TemplatePayloadValidationError;
+import io.flamingock.api.template.TemplateValidationContext;
 
 import java.util.Collections;
 import java.util.List;
@@ -58,7 +59,7 @@ public class TemplateString implements TemplatePayload {
     }
 
     @Override
-    public List<TemplatePayloadValidationError> validate() {
+    public List<TemplatePayloadValidationError> validate(TemplateValidationContext context) {
         if (value == null || value.trim().isEmpty()) {
             return Collections.singletonList(
                     new TemplatePayloadValidationError("value", "must not be null or blank"));

--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/template/wrappers/TemplateVoid.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/template/wrappers/TemplateVoid.java
@@ -17,6 +17,7 @@ package io.flamingock.api.template.wrappers;
 
 import io.flamingock.api.template.TemplatePayload;
 import io.flamingock.api.template.TemplatePayloadValidationError;
+import io.flamingock.api.template.TemplateValidationContext;
 
 import java.util.Collections;
 import java.util.List;
@@ -32,7 +33,7 @@ import java.util.List;
 public class TemplateVoid implements TemplatePayload {
 
     @Override
-    public List<TemplatePayloadValidationError> validate() {
+    public List<TemplatePayloadValidationError> validate(TemplateValidationContext context) {
         return Collections.emptyList();
     }
 }

--- a/core/flamingock-core-api/src/test/java/io/flamingock/api/template/AbstractChangeTemplateReflectiveClassesTest.java
+++ b/core/flamingock-core-api/src/test/java/io/flamingock/api/template/AbstractChangeTemplateReflectiveClassesTest.java
@@ -36,7 +36,7 @@ class AbstractChangeTemplateReflectiveClassesTest {
         public String configValue;
 
         @Override
-        public List<TemplatePayloadValidationError> validate() {
+        public List<TemplatePayloadValidationError> validate(TemplateValidationContext context) {
             return Collections.emptyList();
         }
     }
@@ -46,7 +46,7 @@ class AbstractChangeTemplateReflectiveClassesTest {
         public String applyData;
 
         @Override
-        public List<TemplatePayloadValidationError> validate() {
+        public List<TemplatePayloadValidationError> validate(TemplateValidationContext context) {
             return Collections.emptyList();
         }
     }
@@ -56,7 +56,7 @@ class AbstractChangeTemplateReflectiveClassesTest {
         public String rollbackData;
 
         @Override
-        public List<TemplatePayloadValidationError> validate() {
+        public List<TemplatePayloadValidationError> validate(TemplateValidationContext context) {
             return Collections.emptyList();
         }
     }

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/AbstractTemplateLoadedChange.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/AbstractTemplateLoadedChange.java
@@ -19,6 +19,7 @@ import io.flamingock.api.annotations.Apply;
 import io.flamingock.api.annotations.Rollback;
 import io.flamingock.api.template.ChangeTemplate;
 import io.flamingock.api.template.TemplatePayload;
+import io.flamingock.api.template.TemplateValidationContext;
 import io.flamingock.internal.common.core.error.validation.ValidationError;
 import io.flamingock.internal.common.core.task.RecoveryDescriptor;
 import io.flamingock.internal.common.core.task.TargetSystemDescriptor;
@@ -101,6 +102,12 @@ public abstract class AbstractTemplateLoadedChange<CONFIG extends TemplatePayloa
         errors.addAll(validateApplyPayload());
         errors.addAll(validateRollbackPayload());
         return errors;
+    }
+
+    protected TemplateValidationContext buildValidationContext() {
+        TemplateValidationContext ctx = new TemplateValidationContext();
+        ctx.setTransactional(isTransactional());
+        return ctx;
     }
 
     abstract protected List<ValidationError> validateConfigurationPayload();

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/MultiStepTemplateLoadedChange.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/MultiStepTemplateLoadedChange.java
@@ -19,6 +19,7 @@ import io.flamingock.api.template.AbstractChangeTemplate;
 import io.flamingock.api.template.TemplatePayload;
 import io.flamingock.api.template.TemplatePayloadValidationError;
 import io.flamingock.api.template.TemplateStep;
+import io.flamingock.api.template.TemplateValidationContext;
 import io.flamingock.internal.common.core.error.validation.ValidationError;
 import io.flamingock.internal.common.core.task.RecoveryDescriptor;
 import io.flamingock.internal.common.core.task.TargetSystemDescriptor;
@@ -71,7 +72,8 @@ public class MultiStepTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY
     protected List<ValidationError> validateConfigurationPayload() {
         CONFIG config = getConfigurationPayload();
         if (config != null) {
-            List<TemplatePayloadValidationError> payloadErrors = config.validate();
+            TemplateValidationContext context = buildValidationContext();
+            List<TemplatePayloadValidationError> payloadErrors = config.validate(context);
             if (!payloadErrors.isEmpty()) {
                 List<ValidationError> errors = new ArrayList<>();
                 for (TemplatePayloadValidationError e : payloadErrors) {
@@ -89,6 +91,7 @@ public class MultiStepTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY
     protected List<ValidationError> validateApplyPayload() {
         List<ValidationError> errors = new ArrayList<>();
         if (steps != null) {
+            TemplateValidationContext context = buildValidationContext();
             for (int i = 0; i < steps.size(); i++) {
                 APPLY applyPayload = steps.get(i).getApplyPayload();
                 if (applyPayload == null) {
@@ -96,7 +99,7 @@ public class MultiStepTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY
                             String.format("Template '%s', step %d: missing required 'apply' payload", getSource(), i + 1),
                             getId(), "change"));
                 } else {
-                    List<TemplatePayloadValidationError> payloadErrors = applyPayload.validate();
+                    List<TemplatePayloadValidationError> payloadErrors = applyPayload.validate(context);
                     for (TemplatePayloadValidationError e : payloadErrors) {
                         errors.add(new ValidationError(
                                 String.format("Template '%s', step %d apply payload: %s", getSource(), i + 1, e.getFormattedMessage()),
@@ -112,6 +115,7 @@ public class MultiStepTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY
     protected List<ValidationError> validateRollbackPayload() {
         List<ValidationError> errors = new ArrayList<>();
         if (steps != null) {
+            TemplateValidationContext context = buildValidationContext();
             for (int i = 0; i < steps.size(); i++) {
                 ROLLBACK rollbackPayload = steps.get(i).getRollbackPayload();
                 if (rollbackPayloadRequired && !steps.get(i).hasRollbackPayload()) {
@@ -119,7 +123,7 @@ public class MultiStepTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY
                             String.format("Template '%s', step %d: missing required 'rollback' payload (rollbackPayloadRequired=true)", getSource(), i + 1),
                             getId(), "change"));
                 } else if (rollbackPayload != null) {
-                    List<TemplatePayloadValidationError> payloadErrors = rollbackPayload.validate();
+                    List<TemplatePayloadValidationError> payloadErrors = rollbackPayload.validate(context);
                     for (TemplatePayloadValidationError e : payloadErrors) {
                         errors.add(new ValidationError(
                                 String.format("Template '%s', step %d rollback payload: %s", getSource(), i + 1, e.getFormattedMessage()),

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/SimpleTemplateLoadedChange.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/SimpleTemplateLoadedChange.java
@@ -18,6 +18,7 @@ package io.flamingock.internal.core.task.loaded;
 import io.flamingock.api.template.AbstractChangeTemplate;
 import io.flamingock.api.template.TemplatePayload;
 import io.flamingock.api.template.TemplatePayloadValidationError;
+import io.flamingock.api.template.TemplateValidationContext;
 import io.flamingock.internal.common.core.error.validation.ValidationError;
 import io.flamingock.internal.common.core.task.RecoveryDescriptor;
 import io.flamingock.internal.common.core.task.TargetSystemDescriptor;
@@ -82,7 +83,8 @@ public class SimpleTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY ex
     protected List<ValidationError> validateConfigurationPayload() {
         CONFIG config = getConfigurationPayload();
         if (config != null) {
-            List<TemplatePayloadValidationError> payloadErrors = config.validate();
+            TemplateValidationContext context = buildValidationContext();
+            List<TemplatePayloadValidationError> payloadErrors = config.validate(context);
             if (!payloadErrors.isEmpty()) {
                 List<ValidationError> errors = new ArrayList<>();
                 for (TemplatePayloadValidationError e : payloadErrors) {
@@ -103,7 +105,8 @@ public class SimpleTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY ex
                     String.format("Template '%s' requires 'apply' payload", getSource()),
                     getId(), "change"));
         }
-        List<TemplatePayloadValidationError> payloadErrors = applyPayload.validate();
+        TemplateValidationContext context = buildValidationContext();
+        List<TemplatePayloadValidationError> payloadErrors = applyPayload.validate(context);
         if (!payloadErrors.isEmpty()) {
             List<ValidationError> errors = new ArrayList<>();
             for (TemplatePayloadValidationError e : payloadErrors) {
@@ -124,7 +127,8 @@ public class SimpleTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY ex
                     getId(), "change"));
         }
         if (rollbackPayload != null) {
-            List<TemplatePayloadValidationError> payloadErrors = rollbackPayload.validate();
+            TemplateValidationContext context = buildValidationContext();
+            List<TemplatePayloadValidationError> payloadErrors = rollbackPayload.validate(context);
             if (!payloadErrors.isEmpty()) {
                 List<ValidationError> errors = new ArrayList<>();
                 for (TemplatePayloadValidationError e : payloadErrors) {


### PR DESCRIPTION
- Introduce **TemplateValidationContext** class with `transactional` field
  (default `false`) and a backward-compatibility contract: new fields are
  added via getter/setter with sensible defaults, so older payloads work
  unchanged
- Change `TemplatePayload.validate()` signature to
  `validate(TemplateValidationContext)`, enabling context-aware payload
  validation
- Add `buildValidationContext()` helper in **AbstractTemplateLoadedChange**
  to construct the context from change metadata, used by both
  **SimpleTemplateLoadedChange** and **MultiStepTemplateLoadedChange**
- Update all implementations: **TemplateVoid**, **TemplateString**, and
  test payloads


