### PR TITLE
feat(templates): add TemplatePayloadInfo and restrict transaction-support validation to apply payloads

### DIFF
--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/template/TemplatePayload.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/template/TemplatePayload.java
@@ -33,4 +33,12 @@ public interface TemplatePayload {
      * @return list of validation errors, empty if payload is valid
      */
     List<TemplatePayloadValidationError> validate(TemplateValidationContext context);
+
+    /**
+     * Returns metadata about this payload so the framework can make
+     * centralized decisions based on payload characteristics.
+     *
+     * @return payload info; never {@code null}
+     */
+    TemplatePayloadInfo getInfo();
 }

--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/template/TemplatePayloadInfo.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/template/TemplatePayloadInfo.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Flamingock (https://www.flamingock.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.flamingock.api.template;
+
+import java.util.Optional;
+
+/**
+ * Metadata that a {@link TemplatePayload} exposes to the framework so
+ * centralized decisions can be made based on payload characteristics.
+ *
+ * <p><b>Binary-compatibility contract:</b> new fields are added as
+ * getter/setter pairs.  A {@code null} value means "not specified" —
+ * the payload makes no claim and the framework applies its own policy.
+ * Older implementations that return a default-constructed instance
+ * continue to work unchanged as new fields are introduced.
+ *
+ * <p>Current fields:
+ * <ul>
+ *   <li>{@code supportsTransactions} — whether the payload's target
+ *       system supports transactional execution.  {@code null} (default)
+ *       means the payload makes no claim.</li>
+ * </ul>
+ */
+public class TemplatePayloadInfo {
+
+    private Boolean supportsTransactions;
+
+    /**
+     * Creates an info instance with all fields set to {@code null}
+     * (no claims made).
+     */
+    public TemplatePayloadInfo() {
+    }
+
+    /**
+     * Returns whether the payload's target system supports transactional
+     * execution.
+     *
+     * @return an {@link Optional} containing {@code true} or {@code false}
+     *         if the payload explicitly declares support; empty if the
+     *         payload makes no claim
+     */
+    public Optional<Boolean> getSupportsTransactions() {
+        return Optional.ofNullable(supportsTransactions);
+    }
+
+    /**
+     * Sets whether the payload's target system supports transactional
+     * execution.
+     *
+     * @param supportsTransactions {@code true} if transactions are supported,
+     *                             {@code false} if not, or {@code null} to
+     *                             make no claim
+     */
+    public void setSupportsTransactions(Boolean supportsTransactions) {
+        this.supportsTransactions = supportsTransactions;
+    }
+}

--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/template/wrappers/TemplateString.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/template/wrappers/TemplateString.java
@@ -16,6 +16,7 @@
 package io.flamingock.api.template.wrappers;
 
 import io.flamingock.api.template.TemplatePayload;
+import io.flamingock.api.template.TemplatePayloadInfo;
 import io.flamingock.api.template.TemplatePayloadValidationError;
 import io.flamingock.api.template.TemplateValidationContext;
 
@@ -65,6 +66,11 @@ public class TemplateString implements TemplatePayload {
                     new TemplatePayloadValidationError("value", "must not be null or blank"));
         }
         return Collections.emptyList();
+    }
+
+    @Override
+    public TemplatePayloadInfo getInfo() {
+        return new TemplatePayloadInfo();
     }
 
     @Override

--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/template/wrappers/TemplateVoid.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/template/wrappers/TemplateVoid.java
@@ -16,6 +16,7 @@
 package io.flamingock.api.template.wrappers;
 
 import io.flamingock.api.template.TemplatePayload;
+import io.flamingock.api.template.TemplatePayloadInfo;
 import io.flamingock.api.template.TemplatePayloadValidationError;
 import io.flamingock.api.template.TemplateValidationContext;
 
@@ -35,5 +36,10 @@ public class TemplateVoid implements TemplatePayload {
     @Override
     public List<TemplatePayloadValidationError> validate(TemplateValidationContext context) {
         return Collections.emptyList();
+    }
+
+    @Override
+    public TemplatePayloadInfo getInfo() {
+        return new TemplatePayloadInfo();
     }
 }

--- a/core/flamingock-core-api/src/test/java/io/flamingock/api/template/AbstractChangeTemplateReflectiveClassesTest.java
+++ b/core/flamingock-core-api/src/test/java/io/flamingock/api/template/AbstractChangeTemplateReflectiveClassesTest.java
@@ -39,6 +39,11 @@ class AbstractChangeTemplateReflectiveClassesTest {
         public List<TemplatePayloadValidationError> validate(TemplateValidationContext context) {
             return Collections.emptyList();
         }
+
+        @Override
+        public TemplatePayloadInfo getInfo() {
+            return new TemplatePayloadInfo();
+        }
     }
 
     // Simple test apply payload class
@@ -49,6 +54,11 @@ class AbstractChangeTemplateReflectiveClassesTest {
         public List<TemplatePayloadValidationError> validate(TemplateValidationContext context) {
             return Collections.emptyList();
         }
+
+        @Override
+        public TemplatePayloadInfo getInfo() {
+            return new TemplatePayloadInfo();
+        }
     }
 
     // Simple test rollback payload class
@@ -58,6 +68,11 @@ class AbstractChangeTemplateReflectiveClassesTest {
         @Override
         public List<TemplatePayloadValidationError> validate(TemplateValidationContext context) {
             return Collections.emptyList();
+        }
+
+        @Override
+        public TemplatePayloadInfo getInfo() {
+            return new TemplatePayloadInfo();
         }
     }
 

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/AbstractTemplateLoadedChange.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/AbstractTemplateLoadedChange.java
@@ -25,9 +25,12 @@ import io.flamingock.internal.common.core.task.RecoveryDescriptor;
 import io.flamingock.internal.common.core.task.TargetSystemDescriptor;
 import io.flamingock.internal.core.pipeline.loaded.stage.StageValidationContext;
 import io.flamingock.internal.util.ReflectionUtil;
+import io.flamingock.internal.util.log.FlamingockLoggerFactory;
+import org.slf4j.Logger;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -41,6 +44,8 @@ import java.util.Optional;
  * @param <ROLLBACK> the rollback payload type
  */
 public abstract class AbstractTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload> extends AbstractLoadedChange {
+
+    protected static final Logger logger = FlamingockLoggerFactory.getLogger(AbstractTemplateLoadedChange.class);
 
     private final List<String> profiles;
     private final CONFIG configurationPayload;
@@ -101,6 +106,7 @@ public abstract class AbstractTemplateLoadedChange<CONFIG extends TemplatePayloa
         errors.addAll(validateConfigurationPayload());
         errors.addAll(validateApplyPayload());
         errors.addAll(validateRollbackPayload());
+        warnIfAllPayloadsSupportTransactions();
         return errors;
     }
 
@@ -110,9 +116,32 @@ public abstract class AbstractTemplateLoadedChange<CONFIG extends TemplatePayloa
         return ctx;
     }
 
+    protected List<ValidationError> checkPayloadTransactionSupport(TemplatePayload payload, String payloadLabel) {
+        if (payload == null) {
+            return Collections.emptyList();
+        }
+        Optional<Boolean> supports = payload.getInfo().getSupportsTransactions();
+        if (isTransactional() && supports.isPresent() && !supports.get()) {
+            return Collections.singletonList(new ValidationError(
+                    String.format("Template '%s' is transactional but %s payload does not support transactions",
+                            getSource(), payloadLabel),
+                    getId(), "change"));
+        }
+        return Collections.emptyList();
+    }
+
+    protected static Boolean getExplicitTransactionSupport(TemplatePayload payload) {
+        if (payload == null) {
+            return null;
+        }
+        return payload.getInfo().getSupportsTransactions().orElse(null);
+    }
+
     abstract protected List<ValidationError> validateConfigurationPayload();
 
     abstract protected List<ValidationError> validateApplyPayload();
 
     abstract protected List<ValidationError> validateRollbackPayload();
+
+    abstract protected void warnIfAllPayloadsSupportTransactions();
 }

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/MultiStepTemplateLoadedChange.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/MultiStepTemplateLoadedChange.java
@@ -105,6 +105,7 @@ public class MultiStepTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY
                                 String.format("Template '%s', step %d apply payload: %s", getSource(), i + 1, e.getFormattedMessage()),
                                 getId(), "change"));
                     }
+                    errors.addAll(checkPayloadTransactionSupport(applyPayload, "step " + (i + 1) + " apply"));
                 }
             }
         }
@@ -133,5 +134,30 @@ public class MultiStepTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY
             }
         }
         return errors;
+    }
+
+    @Override
+    protected void warnIfAllPayloadsSupportTransactions() {
+        if (isTransactional()) {
+            return;
+        }
+        if (steps == null || steps.isEmpty()) {
+            return;
+        }
+        boolean atLeastOneExplicit = false;
+        for (TemplateStep<APPLY, ROLLBACK> step : steps) {
+            Boolean supports = getExplicitTransactionSupport(step.getApplyPayload());
+            if (supports == null) {
+                continue;
+            }
+            if (!supports) {
+                return;
+            }
+            atLeastOneExplicit = true;
+        }
+        if (atLeastOneExplicit) {
+            logger.warn("Template '{}': all apply payloads support transactions but change is not transactional. " +
+                    "Consider setting transactional=true", getSource());
+        }
     }
 }

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/SimpleTemplateLoadedChange.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/SimpleTemplateLoadedChange.java
@@ -105,22 +105,21 @@ public class SimpleTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY ex
                     String.format("Template '%s' requires 'apply' payload", getSource()),
                     getId(), "change"));
         }
+        List<ValidationError> errors = new ArrayList<>();
         TemplateValidationContext context = buildValidationContext();
         List<TemplatePayloadValidationError> payloadErrors = applyPayload.validate(context);
-        if (!payloadErrors.isEmpty()) {
-            List<ValidationError> errors = new ArrayList<>();
-            for (TemplatePayloadValidationError e : payloadErrors) {
-                errors.add(new ValidationError(
-                        String.format("Template '%s' apply payload: %s", getSource(), e.getFormattedMessage()),
-                        getId(), "change"));
-            }
-            return errors;
+        for (TemplatePayloadValidationError e : payloadErrors) {
+            errors.add(new ValidationError(
+                    String.format("Template '%s' apply payload: %s", getSource(), e.getFormattedMessage()),
+                    getId(), "change"));
         }
-        return Collections.emptyList();
+        errors.addAll(checkPayloadTransactionSupport(applyPayload, "apply"));
+        return errors;
     }
 
     @Override
     protected List<ValidationError> validateRollbackPayload() {
+        List<ValidationError> errors = new ArrayList<>();
         if (rollbackPayloadRequired && rollbackPayload == null) {
             return Collections.singletonList(new ValidationError(
                     String.format("Template '%s' requires 'rollback' payload (rollbackPayloadRequired=true)", getSource()),
@@ -129,16 +128,24 @@ public class SimpleTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY ex
         if (rollbackPayload != null) {
             TemplateValidationContext context = buildValidationContext();
             List<TemplatePayloadValidationError> payloadErrors = rollbackPayload.validate(context);
-            if (!payloadErrors.isEmpty()) {
-                List<ValidationError> errors = new ArrayList<>();
-                for (TemplatePayloadValidationError e : payloadErrors) {
-                    errors.add(new ValidationError(
-                            String.format("Template '%s' rollback payload: %s", getSource(), e.getFormattedMessage()),
-                            getId(), "change"));
-                }
-                return errors;
+            for (TemplatePayloadValidationError e : payloadErrors) {
+                errors.add(new ValidationError(
+                        String.format("Template '%s' rollback payload: %s", getSource(), e.getFormattedMessage()),
+                        getId(), "change"));
             }
         }
-        return Collections.emptyList();
+        return errors;
+    }
+
+    @Override
+    protected void warnIfAllPayloadsSupportTransactions() {
+        if (isTransactional()) {
+            return;
+        }
+        Boolean supports = getExplicitTransactionSupport(applyPayload);
+        if (Boolean.TRUE.equals(supports)) {
+            logger.warn("Template '{}': apply payload supports transactions but change is not transactional. " +
+                    "Consider setting transactional=true", getSource());
+        }
     }
 }

--- a/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/PayloadTransactionSupportValidationTest.java
+++ b/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/PayloadTransactionSupportValidationTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2026 Flamingock (https://www.flamingock.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.flamingock.internal.core.task.loaded;
+
+import io.flamingock.api.annotations.Apply;
+import io.flamingock.api.annotations.Rollback;
+import io.flamingock.api.template.AbstractChangeTemplate;
+import io.flamingock.api.template.TemplatePayload;
+import io.flamingock.api.template.TemplatePayloadInfo;
+import io.flamingock.api.template.TemplatePayloadValidationError;
+import io.flamingock.api.template.TemplateStep;
+import io.flamingock.api.template.TemplateValidationContext;
+import io.flamingock.api.template.wrappers.TemplateString;
+import io.flamingock.api.template.wrappers.TemplateVoid;
+import io.flamingock.internal.common.core.error.validation.ValidationError;
+import io.flamingock.internal.core.pipeline.loaded.stage.StageValidationContext;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("Payload transaction support validation")
+class PayloadTransactionSupportValidationTest {
+
+    // ── Helper payload classes ──────────────────────────────────────────
+
+    static class NonTransactionalPayload implements TemplatePayload {
+        @Override
+        public List<TemplatePayloadValidationError> validate(TemplateValidationContext context) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public TemplatePayloadInfo getInfo() {
+            TemplatePayloadInfo info = new TemplatePayloadInfo();
+            info.setSupportsTransactions(false);
+            return info;
+        }
+    }
+
+    static class TransactionalPayload implements TemplatePayload {
+        @Override
+        public List<TemplatePayloadValidationError> validate(TemplateValidationContext context) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public TemplatePayloadInfo getInfo() {
+            TemplatePayloadInfo info = new TemplatePayloadInfo();
+            info.setSupportsTransactions(true);
+            return info;
+        }
+    }
+
+    static class UnclaimedPayload implements TemplatePayload {
+        @Override
+        public List<TemplatePayloadValidationError> validate(TemplateValidationContext context) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public TemplatePayloadInfo getInfo() {
+            return new TemplatePayloadInfo();
+        }
+    }
+
+    // ── Dummy template (never instantiated — only .class is used) ───────
+
+    static class DummyTemplate extends AbstractChangeTemplate<TemplateVoid, TemplateString, TemplateString> {
+        @Apply
+        public void apply() {
+        }
+
+        @Rollback
+        public void rollback() {
+        }
+    }
+
+    // ── Shared fixtures ─────────────────────────────────────────────────
+
+    private static final StageValidationContext VALIDATION_CONTEXT = StageValidationContext.builder()
+            .setSorted(StageValidationContext.SortType.UNSORTED)
+            .build();
+
+    private static Constructor<?> dummyConstructor;
+
+    @BeforeAll
+    static void setUp() {
+        dummyConstructor = DummyTemplate.class.getDeclaredConstructors()[0];
+    }
+
+    // ── Factory helpers (raw types to bypass generics mismatch) ─────────
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static SimpleTemplateLoadedChange buildSimple(boolean transactional,
+                                                          TemplatePayload config,
+                                                          TemplatePayload apply,
+                                                          TemplatePayload rollback) {
+        return new SimpleTemplateLoadedChange(
+                "test-file.yml", "test-id", "001", "author",
+                (Class) DummyTemplate.class, dummyConstructor,
+                Collections.emptyList(), transactional,
+                false, false,
+                config, apply, rollback,
+                null, null, false);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static MultiStepTemplateLoadedChange buildMultiStep(boolean transactional,
+                                                                TemplatePayload config,
+                                                                List<TemplateStep> steps) {
+        return new MultiStepTemplateLoadedChange(
+                "test-file.yml", "test-id", "001", "author",
+                (Class) DummyTemplate.class, dummyConstructor,
+                Collections.emptyList(), transactional,
+                false, false,
+                config, (List) steps,
+                null, null, false);
+    }
+
+    // ── Assertion helpers ───────────────────────────────────────────────
+
+    private static boolean isTxSupportError(ValidationError e) {
+        return e.getMessage().contains("does not support transactions");
+    }
+
+    // ═════════════════════════════════════════════════════════════════════
+    //  Simple template tests
+    // ═════════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("SimpleTemplate transaction support validation")
+    class SimpleTemplateValidation {
+
+        @Test
+        @DisplayName("ERROR: transactional change with non-tx apply payload")
+        void transactionalChange_nonTxApplyPayload_shouldError() {
+            List<ValidationError> errors = buildSimple(true, null, new NonTransactionalPayload(), new UnclaimedPayload())
+                    .getValidationErrors(VALIDATION_CONTEXT);
+
+            assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("apply payload does not support transactions")),
+                    "Expected error about apply payload not supporting transactions, but got: " + errors);
+        }
+
+        @Test
+        @DisplayName("No error when all payloads are unclaimed (transactional change)")
+        void transactionalChange_allUnclaimed_noTxError() {
+            List<ValidationError> errors = buildSimple(true, null, new UnclaimedPayload(), new UnclaimedPayload())
+                    .getValidationErrors(VALIDATION_CONTEXT);
+
+            assertFalse(errors.stream().anyMatch(PayloadTransactionSupportValidationTest::isTxSupportError),
+                    "Expected no transaction-support errors, but got: " + errors);
+        }
+
+        @Test
+        @DisplayName("No error when change is non-transactional with non-tx apply payload")
+        void nonTransactionalChange_nonTxApplyPayload_noError() {
+            List<ValidationError> errors = buildSimple(false, null, new NonTransactionalPayload(), null)
+                    .getValidationErrors(VALIDATION_CONTEXT);
+
+            assertFalse(errors.stream().anyMatch(PayloadTransactionSupportValidationTest::isTxSupportError),
+                    "Expected no transaction-support errors, but got: " + errors);
+        }
+
+        @Test
+        @DisplayName("WARNING path: non-tx change but apply payload supports transactions — no validation error")
+        void nonTransactionalChange_txApplyPayload_warningPathNoError() {
+            List<ValidationError> errors = buildSimple(false, null, new TransactionalPayload(), null)
+                    .getValidationErrors(VALIDATION_CONTEXT);
+
+            assertFalse(errors.stream().anyMatch(PayloadTransactionSupportValidationTest::isTxSupportError),
+                    "Warning path must not produce transaction-support validation errors, but got: " + errors);
+        }
+
+        @Test
+        @DisplayName("No warning when non-tx change has unclaimed apply payload")
+        void nonTransactionalChange_unclaimedApplyPayload_noWarning() {
+            List<ValidationError> errors = buildSimple(false, null, new UnclaimedPayload(), null)
+                    .getValidationErrors(VALIDATION_CONTEXT);
+
+            assertFalse(errors.stream().anyMatch(PayloadTransactionSupportValidationTest::isTxSupportError),
+                    "Unclaimed apply payload should not trigger any transaction-support errors, but got: " + errors);
+        }
+
+        @Test
+        @DisplayName("Rollback payload with non-tx is NOT checked for transaction support")
+        void transactionalChange_nonTxRollbackPayload_notChecked() {
+            List<ValidationError> errors = buildSimple(true, null, new UnclaimedPayload(), new NonTransactionalPayload())
+                    .getValidationErrors(VALIDATION_CONTEXT);
+
+            assertFalse(errors.stream().anyMatch(PayloadTransactionSupportValidationTest::isTxSupportError),
+                    "Rollback payload should not be checked for transaction support, but got: " + errors);
+        }
+    }
+
+    // ═════════════════════════════════════════════════════════════════════
+    //  Multi-step template tests
+    // ═════════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("MultiStep transaction support validation")
+    class MultiStepValidation {
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        private TemplateStep step(TemplatePayload apply, TemplatePayload rollback) {
+            return new TemplateStep(apply, rollback);
+        }
+
+        @Test
+        @DisplayName("ERROR: transactional change with non-tx step apply payload")
+        void transactionalChange_stepApplyNonTx_shouldError() {
+            List<ValidationError> errors = buildMultiStep(true, null,
+                    Collections.singletonList(step(new NonTransactionalPayload(), new UnclaimedPayload())))
+                    .getValidationErrors(VALIDATION_CONTEXT);
+
+            assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("step 1 apply payload does not support transactions")),
+                    "Expected error about step 1 apply payload not supporting transactions, but got: " + errors);
+        }
+
+        @Test
+        @DisplayName("WARNING path: non-tx change but all step apply payloads support transactions — no validation error")
+        void nonTransactionalChange_allStepApplyPayloadsTx_warningPathNoError() {
+            List<ValidationError> errors = buildMultiStep(false, null,
+                    Collections.singletonList(step(new TransactionalPayload(), new NonTransactionalPayload())))
+                    .getValidationErrors(VALIDATION_CONTEXT);
+
+            assertFalse(errors.stream().anyMatch(PayloadTransactionSupportValidationTest::isTxSupportError),
+                    "Warning path must not produce transaction-support validation errors, but got: " + errors);
+        }
+
+        @Test
+        @DisplayName("Mixed step apply payloads on non-tx change — no error, no warning")
+        void nonTransactionalChange_mixedStepApplyPayloads_noErrorNoWarning() {
+            List<ValidationError> errors = buildMultiStep(false, null,
+                    Arrays.asList(
+                            step(new TransactionalPayload(), null),
+                            step(new NonTransactionalPayload(), null)))
+                    .getValidationErrors(VALIDATION_CONTEXT);
+
+            assertFalse(errors.stream().anyMatch(PayloadTransactionSupportValidationTest::isTxSupportError),
+                    "Mixed step apply payloads should not trigger transaction-support errors, but got: " + errors);
+        }
+
+        @Test
+        @DisplayName("Step rollback payload with non-tx is NOT checked for transaction support")
+        void transactionalChange_stepRollbackNonTx_notChecked() {
+            List<ValidationError> errors = buildMultiStep(true, null,
+                    Collections.singletonList(step(new UnclaimedPayload(), new NonTransactionalPayload())))
+                    .getValidationErrors(VALIDATION_CONTEXT);
+
+            assertFalse(errors.stream().anyMatch(PayloadTransactionSupportValidationTest::isTxSupportError),
+                    "Step rollback payload should not be checked for transaction support, but got: " + errors);
+        }
+    }
+}


### PR DESCRIPTION
- Add **TemplatePayloadInfo** class with `supportsTransactions` field so payloads can
  declare transaction compatibility via `TemplatePayload.getInfo()`
- Implement `getInfo()` in **TemplateString**, **TemplateVoid**, and test payload stubs
- Add `checkPayloadTransactionSupport()` and `getExplicitTransactionSupport()` helpers
  to **AbstractTemplateLoadedChange** for centralized transaction-support checking
- Restrict transaction-support validation to **apply payloads only** — configuration
  is shared state and rollback is a compensating action, neither represents an actual
  operation against a target system
- `warnIfAllPayloadsSupportTransactions()` now inspects only apply payloads in both
  **SimpleTemplateLoadedChange** and **MultiStepTemplateLoadedChange**
- Add **PayloadTransactionSupportValidationTest** with 10 cases covering error, warning,
  and not-checked paths for both simple and multi-step templates

