### PR TITLE
feat(templates): infer transactional flag from apply payload metadata

### DIFF
--- a/cloud/flamingock-cloud/src/main/java/io/flamingock/cloud/planner/CloudExecutionPlanMapper.java
+++ b/cloud/flamingock-cloud/src/main/java/io/flamingock/cloud/planner/CloudExecutionPlanMapper.java
@@ -34,6 +34,7 @@ import io.flamingock.internal.core.external.store.lock.LockKey;
 import io.flamingock.internal.core.pipeline.execution.ExecutableStage;
 import io.flamingock.internal.core.pipeline.loaded.stage.AbstractLoadedStage;
 import io.flamingock.internal.common.core.task.TaskDescriptor;
+import io.flamingock.internal.core.task.loaded.AbstractLoadedTask;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -66,7 +67,7 @@ public final class CloudExecutionPlanMapper {
         return new ExecutionPlanRequest(lockAcquiredForMillis, requestStages);
     }
 
-    private static TaskRequest mapToTaskRequest(TaskDescriptor descriptor,
+    private static TaskRequest mapToTaskRequest(AbstractLoadedTask descriptor,
                                                 Map<String, TargetSystemAuditMarkType> ongoingStatusesMap) {
         if (ongoingStatusesMap.containsKey(descriptor.getId())) {
             if (ongoingStatusesMap.get(descriptor.getId()) == TargetSystemAuditMarkType.ROLLBACK) {

--- a/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/preview/AbstractPreviewTask.java
+++ b/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/preview/AbstractPreviewTask.java
@@ -37,7 +37,7 @@ public abstract class AbstractPreviewTask extends AbstractTaskDescriptor {
                                String author,
                                String source,
                                boolean runAlways,
-                               boolean transactional,
+                               Boolean transactional,
                                boolean system,
                                TargetSystemDescriptor targetSystem,
                                RecoveryDescriptor recovery,
@@ -60,7 +60,7 @@ public abstract class AbstractPreviewTask extends AbstractTaskDescriptor {
                 ", order='" + order + '\'' +
                 ", source='" + source + '\'' +
                 ", runAlways=" + runAlways +
-                ", transactional=" + transactional +
+                ", transactionalFlag=" + transactionalFlag +
                 ", targetSystem='" + (getTargetSystem() != null ? getTargetSystem().getId() : null) + '\'' +
                 ", recovery='" + (getRecovery() != null ? getRecovery().getStrategy() : null) + '\'' +
                 '}';

--- a/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/preview/CodePreviewChange.java
+++ b/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/preview/CodePreviewChange.java
@@ -40,7 +40,7 @@ public class CodePreviewChange extends AbstractPreviewTask {
                              PreviewMethod applyPreviewMethod,
                              PreviewMethod rollbackPreviewMethod,
                              boolean runAlways,
-                             boolean transactional,
+                             Boolean transactional,
                              boolean system,
                              TargetSystemDescriptor targetSystem,
                              RecoveryDescriptor recovery,
@@ -93,7 +93,7 @@ public class CodePreviewChange extends AbstractPreviewTask {
                 ", author='" + author + '\'' +
                 ", source='" + source + '\'' +
                 ", runAlways=" + runAlways +
-                ", transactional=" + transactional +
+                ", transactionalFlag=" + transactionalFlag +
                 (getTargetSystem() != null ? ", targetSystem='" + getTargetSystem().getId() + '\'' : "") +
                 (getRecovery() != null ? ", recovery='" + getRecovery().getStrategy() + '\'' : "") +
                 '}';

--- a/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/preview/TemplatePreviewChange.java
+++ b/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/preview/TemplatePreviewChange.java
@@ -39,7 +39,7 @@ public class TemplatePreviewChange extends AbstractPreviewTask {
                                  String author,
                                  String templateName,
                                  List<String> profiles,
-                                 boolean transactional,
+                                 Boolean transactional,
                                  boolean runAlways,
                                  boolean system,
                                  Object configuration,
@@ -121,7 +121,7 @@ public class TemplatePreviewChange extends AbstractPreviewTask {
                 ", author='" + author + '\'' +
                 ", source='" + source + '\'' +
                 ", runAlways=" + runAlways +
-                ", transactional=" + transactional +
+                ", transactionalFlag=" + transactionalFlag +
                 ", system=" + system +
                 ", targetSystem='" + (getTargetSystem() != null ? getTargetSystem().getId() : null) + '\'' +
                 ", recovery='" + (getRecovery() != null ? getRecovery().getStrategy() : null) + '\'' +

--- a/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/preview/builder/CodePreviewTaskBuilder.java
+++ b/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/preview/builder/CodePreviewTaskBuilder.java
@@ -50,7 +50,7 @@ public class CodePreviewTaskBuilder implements PreviewTaskBuilder<CodePreviewCha
     private PreviewMethod applyMethod;
     private PreviewMethod rollbackMethod;
     private boolean runAlways = false;
-    private boolean transactional;
+    private Boolean transactionalFlag;
     private boolean system;
     private TargetSystemDescriptor targetSystem;
     private RecoveryDescriptor recovery;
@@ -116,8 +116,8 @@ public class CodePreviewTaskBuilder implements PreviewTaskBuilder<CodePreviewCha
         return this;
     }
 
-    public CodePreviewTaskBuilder setTransactional(boolean transactional) {
-        this.transactional = transactional;
+    public CodePreviewTaskBuilder setTransactionalFlag(Boolean transactionalFlag) {
+        this.transactionalFlag = transactionalFlag;
         return this;
     }
 
@@ -143,7 +143,7 @@ public class CodePreviewTaskBuilder implements PreviewTaskBuilder<CodePreviewCha
             setApplyMethod(getAnnotatedMethodInfo(typeElement, Apply.class).orElse(null));
             setRollbackMethod(getAnnotatedMethodInfo(typeElement, Rollback.class).orElse(null));
             setRunAlways(false); //TODO: how to set runAlways
-            setTransactional(changeAnnotation.transactional());
+            setTransactionalFlag(changeAnnotation.transactional());
             setSystem(false);
         }
         if(targetSystemAnnotation != null) {
@@ -175,7 +175,7 @@ public class CodePreviewTaskBuilder implements PreviewTaskBuilder<CodePreviewCha
                 applyMethod,
                 rollbackMethod,
                 runAlways,
-                transactional,
+                transactionalFlag,
                 system,
                 targetSystem,
                 recovery,

--- a/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/preview/builder/TemplatePreviewTaskBuilder.java
+++ b/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/preview/builder/TemplatePreviewTaskBuilder.java
@@ -36,7 +36,7 @@ class TemplatePreviewTaskBuilder implements PreviewTaskBuilder<TemplatePreviewCh
     private String templateClassPath;
     private String profilesString;
     private boolean runAlways;
-    private Boolean transactional;
+    private Boolean transactionalFlag;
     private Object configuration;
     private Object apply;
     private Object rollback;
@@ -84,8 +84,8 @@ class TemplatePreviewTaskBuilder implements PreviewTaskBuilder<TemplatePreviewCh
         return this;
     }
 
-    public TemplatePreviewTaskBuilder setTransactional(Boolean transactional) {
-        this.transactional = transactional;
+    public TemplatePreviewTaskBuilder setTransactionalFlag(Boolean transactionalFlag) {
+        this.transactionalFlag = transactionalFlag;
         return this;
     }
 
@@ -126,7 +126,7 @@ class TemplatePreviewTaskBuilder implements PreviewTaskBuilder<TemplatePreviewCh
                 author,
                 templateClassPath,
                 profiles,
-                transactional,
+                transactionalFlag,
                 runAlways,
                 false,
                 configuration,
@@ -160,7 +160,7 @@ class TemplatePreviewTaskBuilder implements PreviewTaskBuilder<TemplatePreviewCh
         setApply(templateTaskDescriptor.getApply());
         setRollback(templateTaskDescriptor.getRollback());
         setSteps(templateTaskDescriptor.getSteps());
-        setTransactional(templateTaskDescriptor.getTransactional() != null ? templateTaskDescriptor.getTransactional() : true);
+        setTransactionalFlag(templateTaskDescriptor.getTransactional());
         setRunAlways(false);
         setTargetSystem(templateTaskDescriptor.getTargetSystem());
         setRecovery(templateTaskDescriptor.getRecovery() != null ? templateTaskDescriptor.getRecovery() : RecoveryDescriptor.getDefault());

--- a/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/task/AbstractTaskDescriptor.java
+++ b/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/task/AbstractTaskDescriptor.java
@@ -31,7 +31,7 @@ public abstract class AbstractTaskDescriptor implements TaskDescriptor {
 
     protected boolean runAlways;
 
-    protected boolean transactional;
+    protected Boolean transactionalFlag;
 
     protected boolean system;
 
@@ -48,7 +48,7 @@ public abstract class AbstractTaskDescriptor implements TaskDescriptor {
                                   String author,
                                   String source,
                                   boolean runAlways,
-                                  boolean transactional,
+                                  Boolean transactionalFlag,
                                   boolean system,
                                   TargetSystemDescriptor targetSystem,
                                   RecoveryDescriptor recovery,
@@ -58,7 +58,7 @@ public abstract class AbstractTaskDescriptor implements TaskDescriptor {
         this.author = author;
         this.source = source;
         this.runAlways = runAlways;
-        this.transactional = transactional;
+        this.transactionalFlag = transactionalFlag;
         this.system = system;
         this.targetSystem = targetSystem;
         this.recovery = recovery;
@@ -91,8 +91,8 @@ public abstract class AbstractTaskDescriptor implements TaskDescriptor {
     }
 
     @Override
-    public boolean isTransactional() {
-        return transactional;
+    public Optional<Boolean> getTransactionalFlag() {
+        return Optional.ofNullable(transactionalFlag);
     }
 
     @Override
@@ -135,8 +135,8 @@ public abstract class AbstractTaskDescriptor implements TaskDescriptor {
         this.runAlways = runAlways;
     }
 
-    public void setTransactional(boolean transactional) {
-        this.transactional = transactional;
+    public void setTransactionalFlag(Boolean transactionalFlag) {
+        this.transactionalFlag = transactionalFlag;
     }
 
     public void setSystem(boolean system) {
@@ -179,7 +179,7 @@ public abstract class AbstractTaskDescriptor implements TaskDescriptor {
                 .add("id='" + getId() + "'")
                 .add("author='" + getAuthor() + "'")
                 .add("runAlways=" + isRunAlways())
-                .add("transactional=" + isTransactional())
+                .add("transactionalFlag=" + transactionalFlag)
                 .add("order=" + getOrder())
                 .add("sortable=" + isSortable())
                 .add("targetSystem=" + targetSystem)

--- a/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/task/TaskDescriptor.java
+++ b/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/task/TaskDescriptor.java
@@ -26,7 +26,7 @@ public interface TaskDescriptor extends Comparable<TaskDescriptor> {
 
     boolean isRunAlways();
 
-    boolean isTransactional();
+    Optional<Boolean> getTransactionalFlag();
 
     boolean isSystem();
 

--- a/core/flamingock-core-commons/src/test/java/io/flamingock/internal/common/core/preview/builder/TemplatePreviewTaskBuilderTest.java
+++ b/core/flamingock-core-commons/src/test/java/io/flamingock/internal/common/core/preview/builder/TemplatePreviewTaskBuilderTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Flamingock (https://www.flamingock.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.flamingock.internal.common.core.preview.builder;
+
+import io.flamingock.internal.common.core.preview.TemplatePreviewChange;
+import io.flamingock.internal.common.core.task.TargetSystemDescriptor;
+import io.flamingock.internal.common.core.template.ChangeTemplateFileContent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("TemplatePreviewTaskBuilder transactional nullable support")
+class TemplatePreviewTaskBuilderTest {
+
+    @Test
+    @DisplayName("Should preserve null transactional from YAML")
+    void shouldPreserveNullTransactionalFromYaml() {
+        ChangeTemplateFileContent content = new ChangeTemplateFileContent(
+                "test-id", "author", "SqlTemplate", null,
+                null, null, "CREATE TABLE", null,
+                TargetSystemDescriptor.fromId("postgresql"), null);
+
+        TemplatePreviewChange preview = TemplatePreviewTaskBuilder.builder(content)
+                .setFileName("_0001__test.yaml")
+                .build();
+
+        assertEquals(Optional.empty(), preview.getTransactionalFlag());
+    }
+
+    @Test
+    @DisplayName("Should preserve explicit true transactional from YAML")
+    void shouldPreserveExplicitTrueTransactional() {
+        ChangeTemplateFileContent content = new ChangeTemplateFileContent(
+                "test-id", "author", "SqlTemplate", null,
+                true, null, "CREATE TABLE", null,
+                TargetSystemDescriptor.fromId("postgresql"), null);
+
+        TemplatePreviewChange preview = TemplatePreviewTaskBuilder.builder(content)
+                .setFileName("_0001__test.yaml")
+                .build();
+
+        assertEquals(Optional.of(true), preview.getTransactionalFlag());
+    }
+
+    @Test
+    @DisplayName("Should preserve explicit false transactional from YAML")
+    void shouldPreserveExplicitFalseTransactional() {
+        ChangeTemplateFileContent content = new ChangeTemplateFileContent(
+                "test-id", "author", "SqlTemplate", null,
+                false, null, "CREATE TABLE", null,
+                TargetSystemDescriptor.fromId("postgresql"), null);
+
+        TemplatePreviewChange preview = TemplatePreviewTaskBuilder.builder(content)
+                .setFileName("_0001__test.yaml")
+                .build();
+
+        assertEquals(Optional.of(false), preview.getTransactionalFlag());
+    }
+}

--- a/core/flamingock-core-commons/src/test/java/io/flamingock/internal/common/core/task/AbstractTaskDescriptorTest.java
+++ b/core/flamingock-core-commons/src/test/java/io/flamingock/internal/common/core/task/AbstractTaskDescriptorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Flamingock (https://www.flamingock.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.flamingock.internal.common.core.task;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("AbstractTaskDescriptor transactional nullable support")
+class AbstractTaskDescriptorTest {
+
+    private static AbstractTaskDescriptor createDescriptor(Boolean transactional) {
+        return new AbstractTaskDescriptor(
+                "test-id", "001", "author", "source",
+                false, transactional, false,
+                null, null, false
+        ) {};
+    }
+
+    @Test
+    @DisplayName("getTransactionalFlag() returns empty when field is null")
+    void getTransactionalReturnsEmptyWhenNull() {
+        AbstractTaskDescriptor descriptor = createDescriptor(null);
+        assertEquals(Optional.empty(), descriptor.getTransactionalFlag());
+    }
+
+    @Test
+    @DisplayName("getTransactionalFlag() returns Optional.of(true) when field is true")
+    void getTransactionalReturnsPresentWhenTrue() {
+        AbstractTaskDescriptor descriptor = createDescriptor(true);
+        assertEquals(Optional.of(true), descriptor.getTransactionalFlag());
+    }
+
+    @Test
+    @DisplayName("getTransactionalFlag() returns Optional.of(false) when field is false")
+    void getTransactionalReturnsPresentWhenFalse() {
+        AbstractTaskDescriptor descriptor = createDescriptor(false);
+        assertEquals(Optional.of(false), descriptor.getTransactionalFlag());
+    }
+
+    @Test
+    @DisplayName("setTransactionalFlag() accepts null")
+    void setTransactionalFlagAcceptsNull() {
+        AbstractTaskDescriptor descriptor = createDescriptor(true);
+        descriptor.setTransactionalFlag(null);
+        assertEquals(Optional.empty(), descriptor.getTransactionalFlag());
+    }
+
+    @Test
+    @DisplayName("toString() handles null transactional without throwing")
+    void toStringHandlesNullTransactional() {
+        AbstractTaskDescriptor descriptor = createDescriptor(null);
+        assertDoesNotThrow(() -> descriptor.toString());
+        assertTrue(descriptor.toString().contains("transactionalFlag=null"));
+    }
+}

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/external/store/audit/domain/AuditContextBundle.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/external/store/audit/domain/AuditContextBundle.java
@@ -20,7 +20,7 @@ import io.flamingock.internal.util.ThrowableUtil;
 import io.flamingock.internal.common.core.audit.AuditEntry;
 import io.flamingock.internal.common.cloud.vo.TargetSystemAuditMarkType;
 import io.flamingock.internal.core.pipeline.execution.ExecutionContext;
-import io.flamingock.internal.common.core.task.TaskDescriptor;
+import io.flamingock.internal.core.task.loaded.AbstractLoadedTask;
 
 import static io.flamingock.internal.common.core.audit.AuditEntry.ChangeType.MONGOCK_BEFORE;
 import static io.flamingock.internal.common.core.audit.AuditEntry.ChangeType.MONGOCK_EXECUTION;
@@ -44,14 +44,14 @@ public abstract class AuditContextBundle {
     }
 
     private final Operation operation;
-    private final TaskDescriptor changeDescriptor;
+    private final AbstractLoadedTask changeDescriptor;
     private final ExecutionContext executionContext;
     private final RuntimeContext runtimeContext;
     private final AuditTxType operationType;
     private final String targetSystemId;
 
     public AuditContextBundle(Operation operation,
-                              TaskDescriptor changeDescriptor,
+                              AbstractLoadedTask changeDescriptor,
                               ExecutionContext executionContext,
                               RuntimeContext runtimeContext,
                               AuditTxType auditTxType,
@@ -68,7 +68,7 @@ public abstract class AuditContextBundle {
         return operation;
     }
 
-    public TaskDescriptor getChangeDescriptor() {
+    public AbstractLoadedTask getChangeDescriptor() {
         return changeDescriptor;
     }
 
@@ -90,7 +90,7 @@ public abstract class AuditContextBundle {
 
 
     public AuditEntry toAuditEntry() {
-        TaskDescriptor loadedChange = getChangeDescriptor();
+        AbstractLoadedTask loadedChange = getChangeDescriptor();
         ExecutionContext stageExecutionContext = getExecutionContext();
         RuntimeContext runtimeContext = getRuntimeContext();
         

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/external/store/audit/domain/ExecutionAuditContextBundle.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/external/store/audit/domain/ExecutionAuditContextBundle.java
@@ -17,11 +17,11 @@ package io.flamingock.internal.core.external.store.audit.domain;
 
 import io.flamingock.internal.common.core.audit.AuditTxType;
 import io.flamingock.internal.core.pipeline.execution.ExecutionContext;
-import io.flamingock.internal.common.core.task.TaskDescriptor;
+import io.flamingock.internal.core.task.loaded.AbstractLoadedTask;
 
 public class ExecutionAuditContextBundle extends AuditContextBundle {
 
-    public ExecutionAuditContextBundle(TaskDescriptor loadedTask, ExecutionContext executionContext, RuntimeContext runtimeContext, AuditTxType auditTxType, String targetSystemId) {
+    public ExecutionAuditContextBundle(AbstractLoadedTask loadedTask, ExecutionContext executionContext, RuntimeContext runtimeContext, AuditTxType auditTxType, String targetSystemId) {
         super(Operation.EXECUTION, loadedTask, executionContext, runtimeContext, auditTxType, targetSystemId);
     }
 }

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/external/store/audit/domain/RollbackAuditContextBundle.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/external/store/audit/domain/RollbackAuditContextBundle.java
@@ -17,11 +17,11 @@ package io.flamingock.internal.core.external.store.audit.domain;
 
 import io.flamingock.internal.common.core.audit.AuditTxType;
 import io.flamingock.internal.core.pipeline.execution.ExecutionContext;
-import io.flamingock.internal.common.core.task.TaskDescriptor;
+import io.flamingock.internal.core.task.loaded.AbstractLoadedTask;
 
 public class RollbackAuditContextBundle extends AuditContextBundle {
 
-    public RollbackAuditContextBundle(TaskDescriptor loadedTask, ExecutionContext executionContext, RuntimeContext runtimeContext, AuditTxType auditTxType, String targetSystemId) {
+    public RollbackAuditContextBundle(AbstractLoadedTask loadedTask, ExecutionContext executionContext, RuntimeContext runtimeContext, AuditTxType auditTxType, String targetSystemId) {
         super(Operation.ROLLBACK, loadedTask, executionContext, runtimeContext, auditTxType, targetSystemId);
     }
 }

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/external/store/audit/domain/StartExecutionAuditContextBundle.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/external/store/audit/domain/StartExecutionAuditContextBundle.java
@@ -17,11 +17,11 @@ package io.flamingock.internal.core.external.store.audit.domain;
 
 import io.flamingock.internal.common.core.audit.AuditTxType;
 import io.flamingock.internal.core.pipeline.execution.ExecutionContext;
-import io.flamingock.internal.common.core.task.TaskDescriptor;
+import io.flamingock.internal.core.task.loaded.AbstractLoadedTask;
 
 public class StartExecutionAuditContextBundle extends AuditContextBundle {
 
-    public StartExecutionAuditContextBundle(TaskDescriptor loadedTask, ExecutionContext executionContext, RuntimeContext runtimeContext, AuditTxType auditTxType, String targetSystemId) {
+    public StartExecutionAuditContextBundle(AbstractLoadedTask loadedTask, ExecutionContext executionContext, RuntimeContext runtimeContext, AuditTxType auditTxType, String targetSystemId) {
         super(Operation.START_EXECUTION, loadedTask, executionContext, runtimeContext, auditTxType, targetSystemId);
     }
 }

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/operation/result/ChangeResultBuilder.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/operation/result/ChangeResultBuilder.java
@@ -40,7 +40,7 @@ public class ChangeResultBuilder {
     }
 
     public ChangeResultBuilder fromTask(ExecutableTask task) {
-        TaskDescriptor descriptor = task.getDescriptor();
+        TaskDescriptor descriptor = task.getLoadedChange();
         this.changeId = descriptor.getId();
         this.author = descriptor.getAuthor();
         if (descriptor.getTargetSystem() != null) {

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/pipeline/execution/ExecutableStage.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/pipeline/execution/ExecutableStage.java
@@ -40,7 +40,7 @@ public class ExecutableStage implements StageDescriptor {
 
     @Override
     public Collection<TaskDescriptor> getLoadedTasks() {
-        return tasks.stream().map(ExecutableTask::getDescriptor).collect(Collectors.toList());
+        return tasks.stream().map(ExecutableTask::getLoadedChange).collect(Collectors.toList());
     }
 
     public List<? extends ExecutableTask> getTasks() {

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/AbstractExecutableTask.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/AbstractExecutableTask.java
@@ -16,72 +16,77 @@
 package io.flamingock.internal.core.task.executable;
 
 import io.flamingock.internal.common.core.task.RecoveryDescriptor;
-import io.flamingock.internal.common.core.task.TaskDescriptor;
 import io.flamingock.internal.common.core.task.TargetSystemDescriptor;
 import io.flamingock.internal.common.core.recovery.action.ChangeAction;
+import io.flamingock.internal.core.task.loaded.AbstractLoadedTask;
 
 import java.util.Objects;
 import java.util.Optional;
 
-public abstract class AbstractExecutableTask<DESCRIPTOR extends TaskDescriptor> implements ExecutableTask {
+public abstract class AbstractExecutableTask<LOADED_CHANGE extends AbstractLoadedTask> implements ExecutableTask {
 
     private final String stageName;
 
-    protected final DESCRIPTOR descriptor;
+    protected final LOADED_CHANGE loadedChange;
 
     protected final ChangeAction action;
 
     public AbstractExecutableTask(String stageName,
-                                  DESCRIPTOR descriptor,
+                                  LOADED_CHANGE loadedChange,
                                   ChangeAction action) {
-        if (descriptor == null) {
-            throw new IllegalArgumentException("task descriptor cannot be null");
+        if (loadedChange == null) {
+            throw new IllegalArgumentException("loaded change cannot be null");
         }
         if (action == null) {
             throw new IllegalArgumentException("change action cannot be null");
         }
         this.stageName = stageName;
-        this.descriptor = descriptor;
+        this.loadedChange = loadedChange;
         this.action = action;
     }
     @Override
     public String getId() {
-        return descriptor.getId();
+        return loadedChange.getId();
     }
 
     @Override
     public String getAuthor() {
-        return descriptor.getAuthor();
+        return loadedChange.getAuthor();
     }
 
     @Override
     public boolean isRunAlways() {
-        return descriptor.isRunAlways();
+        return loadedChange.isRunAlways();
     }
 
     @Override
     public boolean isTransactional() {
-        return descriptor.isTransactional();
+        return loadedChange.isTransactional();
+    }
+
+    @Override
+    public Optional<Boolean> getTransactionalFlag() {
+        return loadedChange.getTransactionalFlag();
     }
 
     @Override
     public boolean isSystem() {
-        return descriptor.isSystem();
+        return loadedChange.isSystem();
     }
 
     @Override
     public boolean isLegacy() {
-        return descriptor.isLegacy();
+        return loadedChange.isLegacy();
     }
 
     @Override
     public String getSource() {
-        return descriptor.getSource();
+        return loadedChange.getSource();
     }
 
     @Override
     public Optional<String> getOrder() {
-        return descriptor.getOrder();
+        return loadedChange.getOrder();
     }
 
     @Override
@@ -90,18 +95,18 @@ public abstract class AbstractExecutableTask<DESCRIPTOR extends TaskDescriptor> 
     }
 
     @Override
-    public DESCRIPTOR getDescriptor() {
-        return descriptor;
+    public LOADED_CHANGE getLoadedChange() {
+        return loadedChange;
     }
 
     @Override
     public TargetSystemDescriptor getTargetSystem() {
-        return descriptor.getTargetSystem();
+        return loadedChange.getTargetSystem();
     }
 
     @Override
     public RecoveryDescriptor getRecovery() {
-        return descriptor.getRecovery();
+        return loadedChange.getRecovery();
     }
 
     @Override
@@ -119,18 +124,18 @@ public abstract class AbstractExecutableTask<DESCRIPTOR extends TaskDescriptor> 
         if (this == o) return true;
         if (!(o instanceof AbstractExecutableTask)) return false;
         AbstractExecutableTask<?> that = (AbstractExecutableTask<?>) o;
-        return descriptor.equals(that.descriptor);
+        return loadedChange.equals(that.loadedChange);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(descriptor);
+        return Objects.hash(loadedChange);
     }
 
     @Override
     public String toString() {
         return "ExecutableTask{" +
-                "id='" + descriptor.getId() + '\'' +
+                "id='" + loadedChange.getId() + '\'' +
                 ", action=" + action +
                 ", targetSystem='" + (getTargetSystem() != null ? getTargetSystem().getId() : null) + '\'' +
                 ", recovery='" + (getRecovery() != null ? getRecovery().getStrategy() : null) + '\'' +

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/AbstractTemplateExecutableTask.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/AbstractTemplateExecutableTask.java
@@ -34,29 +34,29 @@ import java.util.Arrays;
  * @param <CONFIG>   the configuration type for the template
  * @param <APPLY>    the apply payload type
  * @param <ROLLBACK> the rollback payload type
- * @param <T>        the type of template loaded change
+ * @param <LOADED_CHANGE>        the type of template loaded change
  */
 public abstract class AbstractTemplateExecutableTask<CONFIG extends TemplatePayload, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload,
-        T extends AbstractTemplateLoadedChange<CONFIG, APPLY, ROLLBACK>> extends ReflectionExecutableTask<T> {
-    protected final Logger logger = FlamingockLoggerFactory.getLogger("TemplateTask");
+        LOADED_CHANGE extends AbstractTemplateLoadedChange<CONFIG, APPLY, ROLLBACK>> extends ReflectionExecutableTask<LOADED_CHANGE> {
+    protected final Logger logger = FlamingockLoggerFactory.getLogger("TemplateExecutableChange");
 
     public AbstractTemplateExecutableTask(String stageName,
-                                          T descriptor,
+                                          LOADED_CHANGE loadedChange,
                                           ChangeAction action,
                                           Method executionMethod,
                                           Method rollbackMethod) {
-        super(stageName, descriptor, action, executionMethod, rollbackMethod);
+        super(stageName, loadedChange, action, executionMethod, rollbackMethod);
     }
 
     protected void setConfigurationData(ChangeTemplate<CONFIG, ?, ?> instance) {
         Class<CONFIG> parameterClass = instance.getConfigurationClass();
-        CONFIG data = descriptor.getConfigurationPayload();
+        CONFIG data = loadedChange.getConfigurationPayload();
 
         if (data != null && TemplateVoid.class != parameterClass) {
             instance.setConfiguration(data);
         } else if (TemplateVoid.class != parameterClass) {
             logger.warn("No 'Configuration' section provided for template-based change[{}] of type[{}]",
-                    descriptor.getId(), descriptor.getTemplateClass().getName());
+                    loadedChange.getId(), loadedChange.getTemplateClass().getName());
         }
     }
 

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/CodeExecutableTask.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/CodeExecutableTask.java
@@ -21,7 +21,6 @@ import io.flamingock.internal.core.runtime.ExecutionRuntime;
 import io.flamingock.internal.core.task.loaded.AbstractReflectionLoadedTask;
 
 import java.lang.reflect.Method;
-import java.util.List;
 
 /**
  * This class is a reflection version of the ExecutableTask.
@@ -36,16 +35,16 @@ import java.util.List;
  * However, the methods are extracted in advance, so we can spot wrong configuration before starting the process and
  * fail fast.
  */
-public class CodeExecutableTask<REFLECTION_TASK_DESCRIPTOR extends AbstractReflectionLoadedTask>
-        extends ReflectionExecutableTask<REFLECTION_TASK_DESCRIPTOR> {
+public class CodeExecutableTask<LOADED_CHANGE extends AbstractReflectionLoadedTask>
+        extends ReflectionExecutableTask<LOADED_CHANGE> {
 
 
     public CodeExecutableTask(String stageName,
-                              REFLECTION_TASK_DESCRIPTOR descriptor,
+                              LOADED_CHANGE loadedChange,
                               ChangeAction action,
                               Method executionMethod,
                               Method rollbackMethod) {
-        super(stageName, descriptor, action, executionMethod, rollbackMethod);
+        super(stageName, loadedChange, action, executionMethod, rollbackMethod);
     }
 
 
@@ -61,7 +60,7 @@ public class CodeExecutableTask<REFLECTION_TASK_DESCRIPTOR extends AbstractRefle
     }
 
     protected void executeInternal(ExecutionRuntime executionRuntime, Method method ) {
-        Object instance = executionRuntime.getInstance(descriptor.getConstructor());
+        Object instance = executionRuntime.getInstance(loadedChange.getConstructor());
         try {
             executionRuntime.executeMethodWithInjectedDependencies(instance, method);
         } catch (Throwable ex) {

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/ExecutableTask.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/ExecutableTask.java
@@ -19,11 +19,11 @@ import io.flamingock.internal.core.runtime.ExecutionRuntime;
 import io.flamingock.internal.common.core.task.TaskDescriptor;
 import io.flamingock.internal.common.core.recovery.action.ChangeAction;
 
-import java.util.List;
-
 public interface ExecutableTask extends TaskDescriptor {
 
-    TaskDescriptor getDescriptor();
+    boolean isTransactional();
+
+    TaskDescriptor getLoadedChange();
 
     String getStageName();
 

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/ReflectionExecutableTask.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/ReflectionExecutableTask.java
@@ -15,14 +15,10 @@
  */
 package io.flamingock.internal.core.task.executable;
 
-import io.flamingock.internal.common.core.error.ChangeExecutionException;
-import io.flamingock.internal.core.runtime.ExecutionRuntime;
 import io.flamingock.internal.core.task.loaded.AbstractReflectionLoadedTask;
 import io.flamingock.internal.common.core.recovery.action.ChangeAction;
 
 import java.lang.reflect.Method;
-import java.util.LinkedList;
-import java.util.List;
 
 /**
  * This class is a reflection version of the ExecutableTask.
@@ -37,19 +33,19 @@ import java.util.List;
  * However, the methods are extracted in advance, so we can spot wrong configuration before starting the process and
  * fail fast.
  */
-public abstract class ReflectionExecutableTask<REFLECTION_TASK_DESCRIPTOR extends AbstractReflectionLoadedTask>
-        extends AbstractExecutableTask<REFLECTION_TASK_DESCRIPTOR> implements ExecutableTask {
+public abstract class ReflectionExecutableTask<LOADED_CHANGE extends AbstractReflectionLoadedTask>
+        extends AbstractExecutableTask<LOADED_CHANGE> implements ExecutableTask {
 
     protected final Method executionMethod;
     protected final Method rollbackMethod;
 
 
     public ReflectionExecutableTask(String stageName,
-                                    REFLECTION_TASK_DESCRIPTOR descriptor,
+                                    LOADED_CHANGE loadedChange,
                                     ChangeAction action,
                                     Method executionMethod,
                                     Method rollbackMethod) {
-        super(stageName, descriptor, action);
+        super(stageName, loadedChange, action);
         this.executionMethod = executionMethod;
         this.rollbackMethod = rollbackMethod;
     }

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/SimpleTemplateExecutableTask.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/SimpleTemplateExecutableTask.java
@@ -38,37 +38,37 @@ public class SimpleTemplateExecutableTask<CONFIG extends TemplatePayload, APPLY 
                 SimpleTemplateLoadedChange<CONFIG, APPLY, ROLLBACK>> {
 
     public SimpleTemplateExecutableTask(String stageName,
-                                        SimpleTemplateLoadedChange<CONFIG, APPLY, ROLLBACK> descriptor,
+                                        SimpleTemplateLoadedChange<CONFIG, APPLY, ROLLBACK> loadedChange,
                                         ChangeAction action,
                                         Method executionMethod,
                                         Method rollbackMethod) {
-        super(stageName, descriptor, action, executionMethod, rollbackMethod);
+        super(stageName, loadedChange, action, executionMethod, rollbackMethod);
     }
 
     @Override
     public void apply(ExecutionRuntime executionRuntime) {
-        logger.debug("Applying change[{}] with template: {}", descriptor.getId(), descriptor.getTemplateClass());
-        logger.debug("change[{}] transactional: {}", descriptor.getId(), descriptor.isTransactional());
+        logger.debug("Applying change[{}] with template: {}", loadedChange.getId(), loadedChange.getTemplateClass());
+        logger.debug("change[{}] transactional: {}", loadedChange.getId(), loadedChange.isTransactional());
         executeInternal(executionRuntime, executionMethod);
     }
 
     @Override
     public void rollback(ExecutionRuntime executionRuntime) {
-        logger.debug("Rolling back change[{}] with template: {}", descriptor.getId(), descriptor.getTemplateClass());
+        logger.debug("Rolling back change[{}] with template: {}", loadedChange.getId(), loadedChange.getTemplateClass());
         executeInternal(executionRuntime, rollbackMethod);
     }
 
     protected void executeInternal(ExecutionRuntime executionRuntime, Method method) {
         try {
             AbstractChangeTemplate instance = (AbstractChangeTemplate)
-                            executionRuntime.getInstance(descriptor.getConstructor());
+                            executionRuntime.getInstance(loadedChange.getConstructor());
 
-            instance.setTransactional(descriptor.isTransactional());
-            instance.setChangeId(descriptor.getId());
-            logger.trace("Setting payloads for simple template change[{}]", descriptor.getId());
+            instance.setTransactional(loadedChange.isTransactional());
+            instance.setChangeId(loadedChange.getId());
+            logger.trace("Setting payloads for simple template change[{}]", loadedChange.getId());
             setConfigurationData(instance);
-            instance.setApplyPayload(descriptor.getApplyPayload());
-            instance.setRollbackPayload(descriptor.getRollbackPayload());
+            instance.setApplyPayload(loadedChange.getApplyPayload());
+            instance.setRollbackPayload(loadedChange.getRollbackPayload());
 
             executionRuntime.executeMethodWithInjectedDependencies(instance, method);
         } catch (Throwable ex) {

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/SteppableTemplateExecutableTask.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/SteppableTemplateExecutableTask.java
@@ -43,11 +43,11 @@ public class SteppableTemplateExecutableTask<CONFIG extends TemplatePayload, APP
     private int stepIndex = -1;
 
     public SteppableTemplateExecutableTask(String stageName,
-                                           MultiStepTemplateLoadedChange<CONFIG, APPLY, ROLLBACK> descriptor,
+                                           MultiStepTemplateLoadedChange<CONFIG, APPLY, ROLLBACK> loadedChange,
                                            ChangeAction action,
                                            Method executionMethod,
                                            Method rollbackMethod) {
-        super(stageName, descriptor, action, executionMethod, rollbackMethod);
+        super(stageName, loadedChange, action, executionMethod, rollbackMethod);
     }
 
     @Override
@@ -55,7 +55,7 @@ public class SteppableTemplateExecutableTask<CONFIG extends TemplatePayload, APP
         AbstractChangeTemplate instance = buildInstance(executionRuntime);
 
         try {
-            List<TemplateStep<APPLY, ROLLBACK>> steps = descriptor.getSteps();
+            List<TemplateStep<APPLY, ROLLBACK>> steps = loadedChange.getSteps();
             while (stepIndex >= -1 && stepIndex + 1 < steps.size()) {
                 TemplateStep<APPLY, ROLLBACK> currentSep = steps.get(stepIndex + 1);
                 instance.setApplyPayload(currentSep.getApplyPayload());
@@ -72,7 +72,7 @@ public class SteppableTemplateExecutableTask<CONFIG extends TemplatePayload, APP
         AbstractChangeTemplate instance = buildInstance(executionRuntime);
 
         try {
-            List<TemplateStep<APPLY, ROLLBACK>> steps = descriptor.getSteps();
+            List<TemplateStep<APPLY, ROLLBACK>> steps = loadedChange.getSteps();
             while (stepIndex >= 0 && stepIndex < steps.size()) {
                 TemplateStep<APPLY, ROLLBACK> currentSep = steps.get(stepIndex);
                 if(currentSep.hasRollbackPayload() && rollbackMethod != null) {
@@ -93,14 +93,14 @@ public class SteppableTemplateExecutableTask<CONFIG extends TemplatePayload, APP
     private AbstractChangeTemplate buildInstance(ExecutionRuntime executionRuntime) {
         AbstractChangeTemplate instance;
         try {
-            logger.debug("Starting execution of change[{}] with template: {}", descriptor.getId(), descriptor.getTemplateClass());
-            logger.debug("change[{}] transactional: {}", descriptor.getId(), descriptor.isTransactional());
+            logger.debug("Starting execution of change[{}] with template: {}", loadedChange.getId(), loadedChange.getTemplateClass());
+            logger.debug("change[{}] transactional: {}", loadedChange.getId(), loadedChange.isTransactional());
 
             instance = (AbstractChangeTemplate)
-                    executionRuntime.getInstance(descriptor.getConstructor());
+                    executionRuntime.getInstance(loadedChange.getConstructor());
 
-            instance.setTransactional(descriptor.isTransactional());
-            instance.setChangeId(descriptor.getId());
+            instance.setTransactional(loadedChange.isTransactional());
+            instance.setChangeId(loadedChange.getId());
             setConfigurationData(instance);
 
         } catch (Throwable ex) {

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/AbstractLoadedChange.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/AbstractLoadedChange.java
@@ -51,12 +51,13 @@ public abstract class AbstractLoadedChange extends AbstractReflectionLoadedTask 
                                    Class<?> implementationClass,
                                    Constructor<?> constructor,
                                    boolean runAlways,
+                                   Boolean transactionalFlag,
                                    boolean transactional,
                                    boolean system,
                                    TargetSystemDescriptor targetSystem,
                                    RecoveryDescriptor recovery,
                                    boolean legacy) {
-        super(fileName, id, order, author, implementationClass, runAlways, transactional, system, targetSystem, recovery, legacy);
+        super(fileName, id, order, author, implementationClass, runAlways, transactionalFlag, transactional, system, targetSystem, recovery, legacy);
 
         this.constructor = constructor;
     }

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/AbstractLoadedTask.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/AbstractLoadedTask.java
@@ -29,17 +29,25 @@ import java.util.Optional;
 
 public abstract class AbstractLoadedTask extends AbstractTaskDescriptor implements Validatable<StageValidationContext> {
 
+    private final boolean transactional;
+
     public AbstractLoadedTask(String id,
                               String order,
                               String author,
                               String implementationSourceName,
                               boolean runAlways,
+                              Boolean transactionalFlag,
                               boolean transactional,
                               boolean system,
                               TargetSystemDescriptor targetSystem,
                               RecoveryDescriptor recovery,
                               boolean legacy) {
-        super(id, order, author, implementationSourceName, runAlways, transactional, system, targetSystem, recovery, legacy);
+        super(id, order, author, implementationSourceName, runAlways, transactionalFlag, system, targetSystem, recovery, legacy);
+        this.transactional = transactional;
+    }
+
+    public boolean isTransactional() {
+        return transactional;
     }
 
     public abstract Constructor<?> getConstructor();

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/AbstractReflectionLoadedTask.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/AbstractReflectionLoadedTask.java
@@ -97,12 +97,13 @@ public abstract class AbstractReflectionLoadedTask extends AbstractLoadedTask {
                                         String author,
                                         Class<?> implementationClass,
                                         boolean runAlways,
+                                        Boolean transactionalFlag,
                                         boolean transactional,
                                         boolean system,
                                         TargetSystemDescriptor targetSystem,
                                         RecoveryDescriptor recovery,
                                         boolean legacy) {
-        super(id, order, author, implementationClass.getName(), runAlways, transactional, system, targetSystem, recovery, legacy);
+        super(id, order, author, implementationClass.getName(), runAlways, transactionalFlag, transactional, system, targetSystem, recovery, legacy);
         this.fileName = fileName;
         this.implementationClass = implementationClass;
     }

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/AbstractTemplateLoadedChange.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/AbstractTemplateLoadedChange.java
@@ -58,6 +58,7 @@ public abstract class AbstractTemplateLoadedChange<CONFIG extends TemplatePayloa
                                            Class<? extends ChangeTemplate<CONFIG, APPLY, ROLLBACK>> templateClass,
                                            Constructor<?> constructor,
                                            List<String> profiles,
+                                           Boolean transactionalFlag,
                                            boolean transactional,
                                            boolean runAlways,
                                            boolean systemTask,
@@ -65,9 +66,8 @@ public abstract class AbstractTemplateLoadedChange<CONFIG extends TemplatePayloa
                                            TargetSystemDescriptor targetSystem,
                                            RecoveryDescriptor recovery,
                                            boolean rollbackPayloadRequired) {
-        super(changeFileName, id, order, author, templateClass, constructor, runAlways, transactional, systemTask, targetSystem, recovery, false);
+        super(changeFileName, id, order, author, templateClass, constructor, runAlways, transactionalFlag, transactional, systemTask, targetSystem, recovery, false);
         this.profiles = profiles;
-        this.transactional = transactional;
         this.configurationPayload = configurationPayload;
         this.rollbackPayloadRequired = rollbackPayloadRequired;
     }

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/CodeLoadedChange.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/CodeLoadedChange.java
@@ -36,12 +36,13 @@ public class CodeLoadedChange extends AbstractLoadedChange {
                      Method applyMethod,
                      Optional<Method> rollbackMethod,
                      boolean runAlways,
+                     Boolean transactionalFlag,
                      boolean transactional,
                      boolean systemTask,
                      TargetSystemDescriptor targetSystem,
                      RecoveryDescriptor recovery,
                      boolean legacy) {
-        super(changeClass.getSimpleName(), id, order, author, changeClass, constructor, runAlways, transactional, systemTask, targetSystem, recovery, legacy);
+        super(changeClass.getSimpleName(), id, order, author, changeClass, constructor, runAlways, transactionalFlag, transactional, systemTask, targetSystem, recovery, legacy);
         this.applyMethod = applyMethod;
         this.rollbackMethod = rollbackMethod;
     }

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/CodeLoadedTaskBuilder.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/CodeLoadedTaskBuilder.java
@@ -43,7 +43,7 @@ public class CodeLoadedTaskBuilder implements LoadedTaskBuilder<CodeLoadedChange
     private Method applyMethod;
     private Optional<Method> rollbackMethod;
     private boolean isRunAlways;
-    private boolean isTransactional;
+    private Boolean transactionalFlag;
     private boolean isSystem;
     private TargetSystemDescriptor targetSystem;
     private RecoveryDescriptor recovery;
@@ -82,7 +82,7 @@ public class CodeLoadedTaskBuilder implements LoadedTaskBuilder<CodeLoadedChange
         setApplyMethod(getApplyMethodFromPreview(preview));
         setRollbackMethod(getRollbackMethodFromPreview(preview));
         setRunAlways(preview.isRunAlways());
-        setTransactional(preview.isTransactional());
+        setTransactionalFlag(preview.getTransactionalFlag().orElse(null));
         setSystem(preview.isSystem());
         setTargetSystem(preview.getTargetSystem());
         setRecovery(preview.getRecovery());
@@ -146,8 +146,8 @@ public class CodeLoadedTaskBuilder implements LoadedTaskBuilder<CodeLoadedChange
         return this;
     }
 
-    public CodeLoadedTaskBuilder setTransactional(boolean transactional) {
-        this.isTransactional = transactional;
+    public CodeLoadedTaskBuilder setTransactionalFlag(Boolean transactionalFlag) {
+        this.transactionalFlag = transactionalFlag;
         return this;
     }
 
@@ -177,6 +177,7 @@ public class CodeLoadedTaskBuilder implements LoadedTaskBuilder<CodeLoadedChange
         Class<?> changeClass = getClassForName(changeClassName);
         String order = ChangeOrderUtil.getMatchedOrderFromClassName(id, orderInContent, changeClassName);
 
+        boolean resolvedTransactional = transactionalFlag != null ? transactionalFlag : true;
         return new CodeLoadedChange(
                 id,
                 order,
@@ -186,7 +187,8 @@ public class CodeLoadedTaskBuilder implements LoadedTaskBuilder<CodeLoadedChange
                 applyMethod,
                 rollbackMethod,
                 isRunAlways,
-                isTransactional,
+                transactionalFlag,
+                resolvedTransactional,
                 isSystem,
                 targetSystem,
                 recovery,
@@ -203,7 +205,7 @@ public class CodeLoadedTaskBuilder implements LoadedTaskBuilder<CodeLoadedChange
         setConstructor(getConstructor(sourceClass));
         setApplyMethod(getApplyMethodFromAnnotation(sourceClass));
         setRollbackMethod(getRollbackMethodFromAnnotation(sourceClass));
-        setTransactional(annotation.transactional());
+        setTransactionalFlag(annotation.transactional());
         setSystem(false);
         setRecoveryFromClass(sourceClass);
         setLegacy(false);

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/LoadedTaskBuilder.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/LoadedTaskBuilder.java
@@ -55,7 +55,7 @@ public interface LoadedTaskBuilder<LOADED_TASK extends AbstractLoadedTask> {
 
     LoadedTaskBuilder<LOADED_TASK> setRunAlways(boolean runAlways);
 
-    LoadedTaskBuilder<LOADED_TASK> setTransactional(boolean transactional);
+    LoadedTaskBuilder<LOADED_TASK> setTransactionalFlag(Boolean transactionalFlag);
 
     LoadedTaskBuilder<LOADED_TASK> setSystem(boolean system);
 

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/MultiStepTemplateLoadedChange.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/MultiStepTemplateLoadedChange.java
@@ -52,6 +52,7 @@ public class MultiStepTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY
                                   Class<? extends AbstractChangeTemplate<CONFIG, APPLY, ROLLBACK>> templateClass,
                                   Constructor<?> constructor,
                                   List<String> profiles,
+                                  Boolean transactionalFlag,
                                   boolean transactional,
                                   boolean runAlways,
                                   boolean systemTask,
@@ -60,7 +61,7 @@ public class MultiStepTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY
                                   TargetSystemDescriptor targetSystem,
                                   RecoveryDescriptor recovery,
                                   boolean rollbackPayloadRequired) {
-        super(changeFileName, id, order, author, templateClass, constructor, profiles, transactional, runAlways, systemTask, configuration, targetSystem, recovery, rollbackPayloadRequired);
+        super(changeFileName, id, order, author, templateClass, constructor, profiles, transactionalFlag, transactional, runAlways, systemTask, configuration, targetSystem, recovery, rollbackPayloadRequired);
         this.steps = steps;
     }
 

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/SimpleTemplateLoadedChange.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/SimpleTemplateLoadedChange.java
@@ -53,6 +53,7 @@ public class SimpleTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY ex
                                Class<? extends AbstractChangeTemplate<CONFIG, APPLY, ROLLBACK>> templateClass,
                                Constructor<?> constructor,
                                List<String> profiles,
+                               Boolean transactionalFlag,
                                boolean transactional,
                                boolean runAlways,
                                boolean systemTask,
@@ -62,7 +63,7 @@ public class SimpleTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY ex
                                TargetSystemDescriptor targetSystem,
                                RecoveryDescriptor recovery,
                                boolean rollbackPayloadRequired) {
-        super(changeFileName, id, order, author, templateClass, constructor, profiles, transactional, runAlways, systemTask, configuration, targetSystem, recovery, rollbackPayloadRequired);
+        super(changeFileName, id, order, author, templateClass, constructor, profiles, transactionalFlag, transactional, runAlways, systemTask, configuration, targetSystem, recovery, rollbackPayloadRequired);
         this.applyPayload = applyPayload;
         this.rollbackPayload = rollbackPayload;
     }

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/TemplateLoadedTaskBuilder.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/TemplateLoadedTaskBuilder.java
@@ -31,17 +31,22 @@ import io.flamingock.internal.common.core.template.TemplateValidator;
 import io.flamingock.internal.util.FileUtil;
 import io.flamingock.internal.util.Pair;
 import io.flamingock.internal.util.ReflectionUtil;
+import io.flamingock.internal.util.log.FlamingockLoggerFactory;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
 
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 
 //TODO how to set transactional and runAlways
 public class TemplateLoadedTaskBuilder implements LoadedTaskBuilder<AbstractTemplateLoadedChange<?, ?, ?>> {
+
+    private static final Logger logger = FlamingockLoggerFactory.getLogger(TemplateLoadedTaskBuilder.class);
 
     private static final TemplateValidator DEFAULT_VALIDATOR = new TemplateValidator();
 
@@ -52,7 +57,7 @@ public class TemplateLoadedTaskBuilder implements LoadedTaskBuilder<AbstractTemp
     private String templateName;
     private List<String> profiles;
     private boolean runAlways;
-    private boolean transactional;
+    private Boolean transactionalFlag;
     private boolean system;
     private Object configuration;
     private Object applyPayload;
@@ -132,8 +137,8 @@ public class TemplateLoadedTaskBuilder implements LoadedTaskBuilder<AbstractTemp
         return this;
     }
 
-    public TemplateLoadedTaskBuilder setTransactional(boolean transactional) {
-        this.transactional = transactional;
+    public TemplateLoadedTaskBuilder setTransactionalFlag(Boolean transactionalFlag) {
+        this.transactionalFlag = transactionalFlag;
         return this;
     }
 
@@ -208,6 +213,7 @@ public class TemplateLoadedTaskBuilder implements LoadedTaskBuilder<AbstractTemp
     private MultiStepTemplateLoadedChange getLoadedMultiStepTemplateChange(Class<? extends AbstractChangeTemplate> steppableTemplateClass, Constructor<?> constructor, boolean rollbackPayloadRequired) {
         List<TemplateStep<Object, Object>> convertedSteps = convertSteps(constructor, steps);// Convert apply/rollback to typed payloads at load time
         TemplatePayload convertedConfig = convertConfiguration(constructor, configuration);
+        boolean resolvedTransactional = resolveTransactionalFromSteps(convertedSteps);
         return new MultiStepTemplateLoadedChange(
                 fileName,
                 id,
@@ -216,7 +222,8 @@ public class TemplateLoadedTaskBuilder implements LoadedTaskBuilder<AbstractTemp
                 steppableTemplateClass,
                 constructor,
                 profiles,
-                transactional,
+                transactionalFlag,
+                resolvedTransactional,
                 runAlways,
                 system,
                 convertedConfig,
@@ -231,6 +238,7 @@ public class TemplateLoadedTaskBuilder implements LoadedTaskBuilder<AbstractTemp
     private SimpleTemplateLoadedChange getLoadedSimpleTemplateChange(Class<? extends AbstractChangeTemplate> simpleTemplateClass, Constructor<?> constructor, boolean rollbackPayloadRequired) {
         Pair<Object, Object> convertedPayloads = convertPayloads(constructor, applyPayload, rollbackPayload);// Convert apply/rollback to typed payloads at load time
         TemplatePayload convertedConfig = convertConfiguration(constructor, configuration);
+        boolean resolvedTransactional = resolveTransactional((TemplatePayload) convertedPayloads.getFirst());
         return new SimpleTemplateLoadedChange(
                 fileName,
                 id,
@@ -239,7 +247,8 @@ public class TemplateLoadedTaskBuilder implements LoadedTaskBuilder<AbstractTemp
                 simpleTemplateClass,
                 constructor,
                 profiles,
-                transactional,
+                transactionalFlag,
+                resolvedTransactional,
                 runAlways,
                 system,
                 convertedConfig,
@@ -359,6 +368,52 @@ public class TemplateLoadedTaskBuilder implements LoadedTaskBuilder<AbstractTemp
         return (TemplatePayload) FileUtil.convertToType(configClass, configData);
     }
 
+    /**
+     * Infers transactional from apply payloads when the user didn't specify it.
+     * Any payload claiming supportsTransactions=false makes the change non-transactional.
+     */
+    private static boolean inferTransactionalFromPayloads(List<TemplatePayload> applyPayloads) {
+        for (TemplatePayload payload : applyPayloads) {
+            if (payload == null) continue;
+            Optional<Boolean> supports = payload.getInfo().getSupportsTransactions();
+            if (supports.isPresent() && !supports.get()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean resolveTransactional(TemplatePayload applyPayload) {
+        if (transactionalFlag != null) return transactionalFlag;
+        boolean inferred = inferTransactionalFromPayloads(
+                applyPayload != null ? Collections.singletonList(applyPayload) : Collections.emptyList());
+        logTransactionalInference(inferred);
+        return inferred;
+    }
+
+    private boolean resolveTransactionalFromSteps(List<TemplateStep<Object, Object>> convertedSteps) {
+        if (transactionalFlag != null) return transactionalFlag;
+        if (convertedSteps == null || convertedSteps.isEmpty()) {
+            logTransactionalInference(true);
+            return true;
+        }
+        List<TemplatePayload> applyPayloads = new ArrayList<>();
+        for (TemplateStep<Object, Object> step : convertedSteps) {
+            applyPayloads.add((TemplatePayload) step.getApplyPayload());
+        }
+        boolean inferred = inferTransactionalFromPayloads(applyPayloads);
+        logTransactionalInference(inferred);
+        return inferred;
+    }
+
+    private void logTransactionalInference(boolean inferred) {
+        if (!inferred) {
+            logger.info("Change '{}': transactional not specified, inferred as non-transactional from apply payload(s)", id);
+        } else {
+            logger.debug("Change '{}': transactional not specified, inferred as transactional (default)", id);
+        }
+    }
+
     private TemplateLoadedTaskBuilder setPreview(TemplatePreviewChange preview) {
         this.preview = preview;
         setFileName(preview.getFileName());
@@ -368,7 +423,7 @@ public class TemplateLoadedTaskBuilder implements LoadedTaskBuilder<AbstractTemp
         setTemplateName(preview.getTemplateName());
         setProfiles(preview.getProfiles());
         setRunAlways(preview.isRunAlways());
-        setTransactional(preview.isTransactional());
+        setTransactionalFlag(preview.getTransactionalFlag().orElse(null));
         setSystem(preview.isSystem());
         setConfiguration(preview.getConfiguration());
         setApplyPayload(preview.getApply());

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/navigation/step/TaskStep.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/navigation/step/TaskStep.java
@@ -15,14 +15,14 @@
  */
 package io.flamingock.internal.core.task.navigation.step;
 
-import io.flamingock.internal.common.core.task.TaskDescriptor;
 import io.flamingock.internal.core.task.executable.ExecutableTask;
+import io.flamingock.internal.core.task.loaded.AbstractLoadedTask;
 
 public interface TaskStep {
     ExecutableTask getTask();
 
-    default TaskDescriptor getLoadedTask() {
-        return getTask().getDescriptor();
+    default AbstractLoadedTask getLoadedTask() {
+        return (AbstractLoadedTask) getTask().getLoadedChange();
     }
 
 }

--- a/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/CodeLoadedTaskBuilderTest.java
+++ b/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/CodeLoadedTaskBuilderTest.java
@@ -44,7 +44,7 @@ class CodeLoadedTaskBuilderTest {
                 .setOrder("001")
                 .setChangeClassName(WithoutOrderTestClass.class.getName())
                 .setRunAlways(false)
-                .setTransactional(true)
+                .setTransactionalFlag(true)
                 .setSystem(false);
 
         // When
@@ -64,7 +64,7 @@ class CodeLoadedTaskBuilderTest {
                 .setOrder("001")
                 .setChangeClassName(_002__MyClass.class.getName())
                 .setRunAlways(false)
-                .setTransactional(true)
+                .setTransactionalFlag(true)
                 .setSystem(false);
 
         // When & Then
@@ -82,7 +82,7 @@ class CodeLoadedTaskBuilderTest {
                 .setOrder(null)
                 .setChangeClassName(WithoutOrderTestClass.class.getName())
                 .setRunAlways(false)
-                .setTransactional(true)
+                .setTransactionalFlag(true)
                 .setSystem(false);
 
         // When & Then
@@ -100,7 +100,7 @@ class CodeLoadedTaskBuilderTest {
                 .setOrder("")
                 .setChangeClassName(_002__MyClass.class.getName())
                 .setRunAlways(false)
-                .setTransactional(true)
+                .setTransactionalFlag(true)
                 .setSystem(false);
 
         // When
@@ -119,7 +119,7 @@ class CodeLoadedTaskBuilderTest {
                 .setOrder("   ")
                 .setChangeClassName(_002__MyClass.class.getName())
                 .setRunAlways(false)
-                .setTransactional(true)
+                .setTransactionalFlag(true)
                 .setSystem(false);
 
         // When
@@ -138,7 +138,7 @@ class CodeLoadedTaskBuilderTest {
                 .setOrder("001")
                 .setChangeClassName(WithoutOrderTestClass.class.getName())
                 .setRunAlways(false)
-                .setTransactional(true)
+                .setTransactionalFlag(true)
                 .setSystem(false);
 
         // When
@@ -151,6 +151,24 @@ class CodeLoadedTaskBuilderTest {
         assertFalse(result.isRunAlways());
         assertTrue(result.isTransactional());
         assertFalse(result.isSystem());
+    }
+
+    @Test
+    @DisplayName("Should default to true when transactional is null")
+    void shouldDefaultToTrueWhenTransactionalIsNull() {
+        // Given
+        builder.setId("test-id")
+                .setOrder("001")
+                .setChangeClassName(WithoutOrderTestClass.class.getName())
+                .setRunAlways(false)
+                .setTransactionalFlag(null)
+                .setSystem(false);
+
+        // When
+        CodeLoadedChange result = builder.build();
+
+        // Then
+        assertTrue(result.isTransactional());
     }
 
     // Test class with Change annotation for testing setFromFlamingockChangeAnnotation

--- a/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/PayloadTransactionSupportValidationTest.java
+++ b/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/PayloadTransactionSupportValidationTest.java
@@ -120,7 +120,7 @@ class PayloadTransactionSupportValidationTest {
         return new SimpleTemplateLoadedChange(
                 "test-file.yml", "test-id", "001", "author",
                 (Class) DummyTemplate.class, dummyConstructor,
-                Collections.emptyList(), transactional,
+                Collections.emptyList(), transactional, transactional,
                 false, false,
                 config, apply, rollback,
                 null, null, false);
@@ -133,7 +133,7 @@ class PayloadTransactionSupportValidationTest {
         return new MultiStepTemplateLoadedChange(
                 "test-file.yml", "test-id", "001", "author",
                 (Class) DummyTemplate.class, dummyConstructor,
-                Collections.emptyList(), transactional,
+                Collections.emptyList(), transactional, transactional,
                 false, false,
                 config, (List) steps,
                 null, null, false);

--- a/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/SimpleTemplateLoadedTaskBuilderTest.java
+++ b/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/SimpleTemplateLoadedTaskBuilderTest.java
@@ -22,6 +22,10 @@ import io.flamingock.internal.common.core.template.ChangeTemplateManager;
 import io.flamingock.api.annotations.ChangeTemplate;
 import io.flamingock.api.annotations.Rollback;
 import io.flamingock.api.template.AbstractChangeTemplate;
+import io.flamingock.api.template.TemplatePayload;
+import io.flamingock.api.template.TemplatePayloadInfo;
+import io.flamingock.api.template.TemplatePayloadValidationError;
+import io.flamingock.api.template.TemplateValidationContext;
 import io.flamingock.api.template.wrappers.TemplateString;
 import io.flamingock.api.template.wrappers.TemplateVoid;
 import io.flamingock.api.annotations.Apply;
@@ -33,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -61,6 +66,78 @@ class SimpleTemplateLoadedTaskBuilderTest {
         }
     }
 
+    // Payload that explicitly claims supportsTransactions=false
+    public static class NonTxPayload implements TemplatePayload {
+        private String value;
+
+        public NonTxPayload() {}
+
+        public NonTxPayload(String value) { this.value = value; }
+
+        public String getValue() { return value; }
+
+        public void setValue(String value) { this.value = value; }
+
+        @Override
+        public List<TemplatePayloadValidationError> validate(TemplateValidationContext context) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public TemplatePayloadInfo getInfo() {
+            TemplatePayloadInfo info = new TemplatePayloadInfo();
+            info.setSupportsTransactions(false);
+            return info;
+        }
+    }
+
+    // Payload that explicitly claims supportsTransactions=true
+    public static class TxPayload implements TemplatePayload {
+        private String value;
+
+        public TxPayload() {}
+
+        public TxPayload(String value) { this.value = value; }
+
+        public String getValue() { return value; }
+
+        public void setValue(String value) { this.value = value; }
+
+        @Override
+        public List<TemplatePayloadValidationError> validate(TemplateValidationContext context) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public TemplatePayloadInfo getInfo() {
+            TemplatePayloadInfo info = new TemplatePayloadInfo();
+            info.setSupportsTransactions(true);
+            return info;
+        }
+    }
+
+    @ChangeTemplate(name = "test-nontx-template")
+    public static class NonTxTemplate extends AbstractChangeTemplate<TemplateVoid, NonTxPayload, TemplateString> {
+        public NonTxTemplate() { super(); }
+
+        @Apply
+        public void apply() {}
+
+        @Rollback
+        public void rollback() {}
+    }
+
+    @ChangeTemplate(name = "test-tx-template")
+    public static class TxTemplate extends AbstractChangeTemplate<TemplateVoid, TxPayload, TemplateString> {
+        public TxTemplate() { super(); }
+
+        @Apply
+        public void apply() {}
+
+        @Rollback
+        public void rollback() {}
+    }
+
     @BeforeEach
     void setUp() {
         builder = TemplateLoadedTaskBuilder.getInstance();
@@ -79,7 +156,7 @@ class SimpleTemplateLoadedTaskBuilderTest {
                     .setFileName("test-file.yml")
                     .setTemplateName("test-template")
                     .setRunAlways(false)
-                    .setTransactional(true)
+                    .setTransactionalFlag(true)
                     .setSystem(false)
                     .setConfiguration(null)
                     .setApplyPayload("applyPayload")
@@ -115,7 +192,7 @@ class SimpleTemplateLoadedTaskBuilderTest {
                     .setFileName("_0002__test-file.yml")
                     .setTemplateName("test-template")
                     .setRunAlways(false)
-                    .setTransactional(true)
+                    .setTransactionalFlag(true)
                     .setSystem(false)
                     .setConfiguration(null)
                     .setApplyPayload("applyPayload")
@@ -147,7 +224,7 @@ class SimpleTemplateLoadedTaskBuilderTest {
                     .setTemplateName("test-template")
                     .setRunAlways(false);
             builder.setProfiles(Arrays.asList("test"));
-            builder.setTransactional(true)
+            builder.setTransactionalFlag(true)
                     .setSystem(false)
                     .setConfiguration(null)
                     .setApplyPayload("applyPayload")
@@ -185,6 +262,79 @@ class SimpleTemplateLoadedTaskBuilderTest {
     }
 
     @Nested
+    @DisplayName("Transactional nullable support tests")
+    class TransactionalNullableTests {
+
+        @Test
+        @DisplayName("Should default to true when transactional is null")
+        void shouldDefaultToTrueWhenTransactionalIsNull() {
+            try (MockedStatic<ChangeTemplateManager> mockedTemplateManager = mockStatic(ChangeTemplateManager.class)) {
+                mockedTemplateManager.when(() -> ChangeTemplateManager.getTemplate("test-template"))
+                        .thenReturn(Optional.of(new ChangeTemplateDefinition("test-change-template", TestChangeTemplate.class, false, true)));
+
+                builder.setId("test-id")
+                        .setOrder("001")
+                        .setFileName("test-file.yml")
+                        .setTemplateName("test-template")
+                        .setRunAlways(false)
+                        .setTransactionalFlag(null)
+                        .setSystem(false)
+                        .setApplyPayload("applyPayload")
+                        .setRollbackPayload("rollbackPayload");
+                builder.setProfiles(Arrays.asList("test"));
+
+                AbstractTemplateLoadedChange<?, ?, ?> result = builder.build();
+
+                assertTrue(result.isTransactional());
+            }
+        }
+
+        @Test
+        @DisplayName("Should preserve explicit true when set")
+        void shouldPreserveExplicitTrueWhenSet() {
+            try (MockedStatic<ChangeTemplateManager> mockedTemplateManager = mockStatic(ChangeTemplateManager.class)) {
+                mockedTemplateManager.when(() -> ChangeTemplateManager.getTemplate("test-template"))
+                        .thenReturn(Optional.of(new ChangeTemplateDefinition("test-change-template", TestChangeTemplate.class, false, true)));
+
+                builder.setId("test-id")
+                        .setOrder("001")
+                        .setFileName("test-file.yml")
+                        .setTemplateName("test-template")
+                        .setTransactionalFlag(true)
+                        .setApplyPayload("applyPayload")
+                        .setRollbackPayload("rollbackPayload");
+                builder.setProfiles(Arrays.asList("test"));
+
+                AbstractTemplateLoadedChange<?, ?, ?> result = builder.build();
+
+                assertTrue(result.isTransactional());
+            }
+        }
+
+        @Test
+        @DisplayName("Should preserve explicit false when set")
+        void shouldPreserveExplicitFalseWhenSet() {
+            try (MockedStatic<ChangeTemplateManager> mockedTemplateManager = mockStatic(ChangeTemplateManager.class)) {
+                mockedTemplateManager.when(() -> ChangeTemplateManager.getTemplate("test-template"))
+                        .thenReturn(Optional.of(new ChangeTemplateDefinition("test-change-template", TestChangeTemplate.class, false, true)));
+
+                builder.setId("test-id")
+                        .setOrder("001")
+                        .setFileName("test-file.yml")
+                        .setTemplateName("test-template")
+                        .setTransactionalFlag(false)
+                        .setApplyPayload("applyPayload")
+                        .setRollbackPayload("rollbackPayload");
+                builder.setProfiles(Arrays.asList("test"));
+
+                AbstractTemplateLoadedChange<?, ?, ?> result = builder.build();
+
+                assertFalse(result.isTransactional());
+            }
+        }
+    }
+
+    @Nested
     @DisplayName("Payload validation tests")
     class ValidationTests {
 
@@ -202,7 +352,7 @@ class SimpleTemplateLoadedTaskBuilderTest {
                 builder.setId("test-id")
                         .setFileName("test-file.yml")
                         .setTemplateName("test-template")
-                        .setTransactional(true)
+                        .setTransactionalFlag(true)
                         .setApplyPayload(null)
                         .setRollbackPayload("rollbackPayload");
                 builder.setProfiles(Arrays.asList("test"));
@@ -225,7 +375,7 @@ class SimpleTemplateLoadedTaskBuilderTest {
                 builder.setId("test-id")
                         .setFileName("test-file.yml")
                         .setTemplateName("test-template")
-                        .setTransactional(true)
+                        .setTransactionalFlag(true)
                         .setApplyPayload("applyPayload")
                         .setRollbackPayload(null);
                 builder.setProfiles(Arrays.asList("test"));
@@ -248,7 +398,7 @@ class SimpleTemplateLoadedTaskBuilderTest {
                 builder.setId("test-id")
                         .setFileName("test-file.yml")
                         .setTemplateName("test-template")
-                        .setTransactional(true)
+                        .setTransactionalFlag(true)
                         .setApplyPayload("applyPayload")
                         .setRollbackPayload(null);
                 builder.setProfiles(Arrays.asList("test"));
@@ -258,6 +408,131 @@ class SimpleTemplateLoadedTaskBuilderTest {
 
                 assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("rollback")),
                         "Expected no rollback-related errors, but got: " + errors);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Transactional inference from payload tests")
+    class TransactionalInferenceTests {
+
+        @Test
+        @DisplayName("Should infer false when payload does not support transactions")
+        void shouldInferFalseWhenPayloadDoesNotSupportTx() {
+            try (MockedStatic<ChangeTemplateManager> mockedTemplateManager = mockStatic(ChangeTemplateManager.class)) {
+                mockedTemplateManager.when(() -> ChangeTemplateManager.getTemplate("test-nontx-template"))
+                        .thenReturn(Optional.of(new ChangeTemplateDefinition("test-nontx-template", NonTxTemplate.class, false, false)));
+
+                builder.setId("test-id")
+                        .setFileName("test-file.yml")
+                        .setTemplateName("test-nontx-template")
+                        .setTransactionalFlag(null)
+                        .setApplyPayload("applyPayload");
+                builder.setProfiles(Arrays.asList("test"));
+
+                AbstractTemplateLoadedChange<?, ?, ?> result = builder.build();
+
+                assertFalse(result.isTransactional());
+            }
+        }
+
+        @Test
+        @DisplayName("Should infer true when payload supports transactions")
+        void shouldInferTrueWhenPayloadSupportsTx() {
+            try (MockedStatic<ChangeTemplateManager> mockedTemplateManager = mockStatic(ChangeTemplateManager.class)) {
+                mockedTemplateManager.when(() -> ChangeTemplateManager.getTemplate("test-tx-template"))
+                        .thenReturn(Optional.of(new ChangeTemplateDefinition("test-tx-template", TxTemplate.class, false, false)));
+
+                builder.setId("test-id")
+                        .setFileName("test-file.yml")
+                        .setTemplateName("test-tx-template")
+                        .setTransactionalFlag(null)
+                        .setApplyPayload("applyPayload");
+                builder.setProfiles(Arrays.asList("test"));
+
+                AbstractTemplateLoadedChange<?, ?, ?> result = builder.build();
+
+                assertTrue(result.isTransactional());
+            }
+        }
+
+        @Test
+        @DisplayName("Should infer true when payload makes no claim")
+        void shouldInferTrueWhenPayloadMakesNoClaim() {
+            try (MockedStatic<ChangeTemplateManager> mockedTemplateManager = mockStatic(ChangeTemplateManager.class)) {
+                mockedTemplateManager.when(() -> ChangeTemplateManager.getTemplate("test-template"))
+                        .thenReturn(Optional.of(new ChangeTemplateDefinition("test-change-template", TestChangeTemplate.class, false, false)));
+
+                builder.setId("test-id")
+                        .setFileName("test-file.yml")
+                        .setTemplateName("test-template")
+                        .setTransactionalFlag(null)
+                        .setApplyPayload("applyPayload");
+                builder.setProfiles(Arrays.asList("test"));
+
+                AbstractTemplateLoadedChange<?, ?, ?> result = builder.build();
+
+                assertTrue(result.isTransactional());
+            }
+        }
+
+        @Test
+        @DisplayName("Should infer true when apply payload is null")
+        void shouldInferTrueWhenApplyPayloadIsNull() {
+            try (MockedStatic<ChangeTemplateManager> mockedTemplateManager = mockStatic(ChangeTemplateManager.class)) {
+                mockedTemplateManager.when(() -> ChangeTemplateManager.getTemplate("test-template"))
+                        .thenReturn(Optional.of(new ChangeTemplateDefinition("test-change-template", TestChangeTemplate.class, false, false)));
+
+                builder.setId("test-id")
+                        .setFileName("test-file.yml")
+                        .setTemplateName("test-template")
+                        .setTransactionalFlag(null)
+                        .setApplyPayload(null);
+                builder.setProfiles(Arrays.asList("test"));
+
+                AbstractTemplateLoadedChange<?, ?, ?> result = builder.build();
+
+                assertTrue(result.isTransactional());
+            }
+        }
+
+        @Test
+        @DisplayName("Should respect explicit true even when payload does not support transactions")
+        void shouldRespectExplicitTrueEvenWhenPayloadDoesNotSupportTx() {
+            try (MockedStatic<ChangeTemplateManager> mockedTemplateManager = mockStatic(ChangeTemplateManager.class)) {
+                mockedTemplateManager.when(() -> ChangeTemplateManager.getTemplate("test-nontx-template"))
+                        .thenReturn(Optional.of(new ChangeTemplateDefinition("test-nontx-template", NonTxTemplate.class, false, false)));
+
+                builder.setId("test-id")
+                        .setFileName("test-file.yml")
+                        .setTemplateName("test-nontx-template")
+                        .setTransactionalFlag(true)
+                        .setApplyPayload("applyPayload");
+                builder.setProfiles(Arrays.asList("test"));
+
+                AbstractTemplateLoadedChange<?, ?, ?> result = builder.build();
+
+                assertTrue(result.isTransactional());
+            }
+        }
+
+        @Test
+        @DisplayName("Should respect explicit false even when payload supports transactions")
+        void shouldRespectExplicitFalseEvenWhenPayloadSupportsTx() {
+            try (MockedStatic<ChangeTemplateManager> mockedTemplateManager = mockStatic(ChangeTemplateManager.class)) {
+                mockedTemplateManager.when(() -> ChangeTemplateManager.getTemplate("test-tx-template"))
+                        .thenReturn(Optional.of(new ChangeTemplateDefinition("test-tx-template", TxTemplate.class, false, false)));
+
+                builder.setId("test-id")
+                        .setFileName("test-file.yml")
+                        .setTemplateName("test-tx-template")
+                        .setTransactionalFlag(false)
+                        .setApplyPayload("applyPayload");
+                builder.setProfiles(Arrays.asList("test"));
+
+                AbstractTemplateLoadedChange<?, ?, ?> result = builder.build();
+
+                assertFalse(result.isTransactional());
             }
         }
     }

--- a/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/SteppableTemplateLoadedTaskBuilderTest.java
+++ b/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/SteppableTemplateLoadedTaskBuilderTest.java
@@ -19,7 +19,11 @@ import io.flamingock.api.annotations.Apply;
 import io.flamingock.api.annotations.ChangeTemplate;
 import io.flamingock.api.annotations.Rollback;
 import io.flamingock.api.template.AbstractChangeTemplate;
+import io.flamingock.api.template.TemplatePayload;
+import io.flamingock.api.template.TemplatePayloadInfo;
+import io.flamingock.api.template.TemplatePayloadValidationError;
 import io.flamingock.api.template.TemplateStep;
+import io.flamingock.api.template.TemplateValidationContext;
 import io.flamingock.api.template.wrappers.TemplateString;
 import io.flamingock.api.template.wrappers.TemplateVoid;
 import io.flamingock.internal.common.core.error.FlamingockException;
@@ -85,6 +89,78 @@ class SteppableTemplateLoadedTaskBuilderTest {
         }
     }
 
+    // Payload that explicitly claims supportsTransactions=false
+    public static class NonTxPayload implements TemplatePayload {
+        private String value;
+
+        public NonTxPayload() {}
+
+        public NonTxPayload(String value) { this.value = value; }
+
+        public String getValue() { return value; }
+
+        public void setValue(String value) { this.value = value; }
+
+        @Override
+        public List<TemplatePayloadValidationError> validate(TemplateValidationContext context) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public TemplatePayloadInfo getInfo() {
+            TemplatePayloadInfo info = new TemplatePayloadInfo();
+            info.setSupportsTransactions(false);
+            return info;
+        }
+    }
+
+    // Payload that explicitly claims supportsTransactions=true
+    public static class TxPayload implements TemplatePayload {
+        private String value;
+
+        public TxPayload() {}
+
+        public TxPayload(String value) { this.value = value; }
+
+        public String getValue() { return value; }
+
+        public void setValue(String value) { this.value = value; }
+
+        @Override
+        public List<TemplatePayloadValidationError> validate(TemplateValidationContext context) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public TemplatePayloadInfo getInfo() {
+            TemplatePayloadInfo info = new TemplatePayloadInfo();
+            info.setSupportsTransactions(true);
+            return info;
+        }
+    }
+
+    @ChangeTemplate(name = "test-nontx-steppable-template", multiStep = true)
+    public static class NonTxSteppableTemplate extends AbstractChangeTemplate<TemplateVoid, NonTxPayload, TemplateString> {
+        public NonTxSteppableTemplate() { super(); }
+
+        @Apply
+        public void apply() {}
+
+        @Rollback
+        public void rollback() {}
+    }
+
+    @ChangeTemplate(name = "test-tx-steppable-template", multiStep = true)
+    public static class TxSteppableTemplate extends AbstractChangeTemplate<TemplateVoid, TxPayload, TemplateString> {
+        public TxSteppableTemplate() { super(); }
+
+        @Apply
+        public void apply() {}
+
+        @Rollback
+        public void rollback() {}
+    }
+
     @BeforeEach
     void setUp() {
         builder = TemplateLoadedTaskBuilder.getInstance();
@@ -106,7 +182,7 @@ class SteppableTemplateLoadedTaskBuilderTest {
             builder.setId("test-id")
                     .setFileName("test-file.yml")
                     .setTemplateName("test-steppable-template")
-                    .setTransactional(true)
+                    .setTransactionalFlag(true)
                     .setSteps(rawSteps);
             builder.setProfiles(Arrays.asList("test"));
 
@@ -144,7 +220,7 @@ class SteppableTemplateLoadedTaskBuilderTest {
                     .setFileName("test-file.yml")
                     .setTemplateName("test-steppable-template")
                     .setRunAlways(false)
-                    .setTransactional(true)
+                    .setTransactionalFlag(true)
                     .setSystem(false)
                     .setConfiguration(null)
                     .setSteps(rawSteps);
@@ -178,7 +254,7 @@ class SteppableTemplateLoadedTaskBuilderTest {
                     .setFileName("_0002__test-file.yml")
                     .setTemplateName("test-steppable-template")
                     .setRunAlways(false)
-                    .setTransactional(true)
+                    .setTransactionalFlag(true)
                     .setSystem(false)
                     .setConfiguration(null)
                     .setSteps(rawSteps);
@@ -208,7 +284,7 @@ class SteppableTemplateLoadedTaskBuilderTest {
             builder.setId("test-id")
                     .setFileName("test-file.yml")
                     .setTemplateName("test-steppable-template")
-                    .setTransactional(true)
+                    .setTransactionalFlag(true)
                     .setSteps(emptySteps);
             builder.setProfiles(Arrays.asList("test"));
 
@@ -244,7 +320,7 @@ class SteppableTemplateLoadedTaskBuilderTest {
                     .setOrder("003")
                     .setFileName("_003__multi-step.yml")
                     .setTemplateName("test-steppable-template")
-                    .setTransactional(true)
+                    .setTransactionalFlag(true)
                     .setSteps(rawSteps);
             builder.setProfiles(Arrays.asList("test"));
 
@@ -308,7 +384,7 @@ class SteppableTemplateLoadedTaskBuilderTest {
             builder.setId("test-id")
                     .setFileName("test-file.yml")
                     .setTemplateName("test-steppable-template")
-                    .setTransactional(true)
+                    .setTransactionalFlag(true)
                     .setSteps(rawSteps);
             builder.setProfiles(Arrays.asList("test"));
 
@@ -338,7 +414,7 @@ class SteppableTemplateLoadedTaskBuilderTest {
             builder.setId("test-id")
                     .setFileName("test-file.yml")
                     .setTemplateName("test-steppable-template")
-                    .setTransactional(true)
+                    .setTransactionalFlag(true)
                     .setSteps(null);
             builder.setProfiles(Arrays.asList("test"));
 
@@ -366,6 +442,59 @@ class SteppableTemplateLoadedTaskBuilderTest {
         Map<String, Object> step = new HashMap<>();
         step.put("apply", apply);
         return step;
+    }
+
+    @Nested
+    @DisplayName("Transactional nullable support tests")
+    class TransactionalNullableTests {
+
+        @Test
+        @DisplayName("Should default to true when transactional is null")
+        void shouldDefaultToTrueWhenTransactionalIsNull() {
+            try (MockedStatic<ChangeTemplateManager> mockedTemplateManager = mockStatic(ChangeTemplateManager.class)) {
+                mockedTemplateManager.when(() -> ChangeTemplateManager.getTemplate("test-steppable-template"))
+                        .thenReturn(Optional.of(new ChangeTemplateDefinition("test-steppable-template", TestSteppableTemplate.class, true, true)));
+
+                List<Map<String, Object>> rawSteps = Collections.singletonList(
+                        createStepMap("apply1", "rollback1")
+                );
+
+                builder.setId("test-id")
+                        .setFileName("test-file.yml")
+                        .setTemplateName("test-steppable-template")
+                        .setTransactionalFlag(null)
+                        .setSteps(rawSteps);
+                builder.setProfiles(Arrays.asList("test"));
+
+                AbstractTemplateLoadedChange<?, ?, ?> result = builder.build();
+
+                assertTrue(result.isTransactional());
+            }
+        }
+
+        @Test
+        @DisplayName("Should preserve explicit false when set")
+        void shouldPreserveExplicitFalseWhenSet() {
+            try (MockedStatic<ChangeTemplateManager> mockedTemplateManager = mockStatic(ChangeTemplateManager.class)) {
+                mockedTemplateManager.when(() -> ChangeTemplateManager.getTemplate("test-steppable-template"))
+                        .thenReturn(Optional.of(new ChangeTemplateDefinition("test-steppable-template", TestSteppableTemplate.class, true, true)));
+
+                List<Map<String, Object>> rawSteps = Collections.singletonList(
+                        createStepMap("apply1", "rollback1")
+                );
+
+                builder.setId("test-id")
+                        .setFileName("test-file.yml")
+                        .setTemplateName("test-steppable-template")
+                        .setTransactionalFlag(false)
+                        .setSteps(rawSteps);
+                builder.setProfiles(Arrays.asList("test"));
+
+                AbstractTemplateLoadedChange<?, ?, ?> result = builder.build();
+
+                assertFalse(result.isTransactional());
+            }
+        }
     }
 
     @Nested
@@ -462,7 +591,7 @@ class SteppableTemplateLoadedTaskBuilderTest {
                 builder.setId("test-id")
                         .setFileName("test-file.yml")
                         .setTemplateName("test-steppable-template")
-                        .setTransactional(true)
+                        .setTransactionalFlag(true)
                         .setSteps(rawSteps);
                 builder.setProfiles(Arrays.asList("test"));
 
@@ -489,7 +618,7 @@ class SteppableTemplateLoadedTaskBuilderTest {
                 builder.setId("test-id")
                         .setFileName("test-file.yml")
                         .setTemplateName("test-steppable-template")
-                        .setTransactional(true)
+                        .setTransactionalFlag(true)
                         .setSteps(rawSteps);
                 builder.setProfiles(Arrays.asList("test"));
 
@@ -516,7 +645,7 @@ class SteppableTemplateLoadedTaskBuilderTest {
                 builder.setId("test-id")
                         .setFileName("test-file.yml")
                         .setTemplateName("test-steppable-template")
-                        .setTransactional(true)
+                        .setTransactionalFlag(true)
                         .setSteps(rawSteps);
                 builder.setProfiles(Arrays.asList("test"));
 
@@ -525,6 +654,176 @@ class SteppableTemplateLoadedTaskBuilderTest {
 
                 assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("rollback")),
                         "Expected no rollback-related errors, but got: " + errors);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Transactional inference from payload tests")
+    class TransactionalInferenceTests {
+
+        @Test
+        @DisplayName("Should infer false when any step does not support transactions")
+        void shouldInferFalseWhenAnyStepDoesNotSupportTx() {
+            try (MockedStatic<ChangeTemplateManager> mockedTemplateManager = mockStatic(ChangeTemplateManager.class)) {
+                mockedTemplateManager.when(() -> ChangeTemplateManager.getTemplate("test-nontx-steppable-template"))
+                        .thenReturn(Optional.of(new ChangeTemplateDefinition("test-nontx-steppable-template", NonTxSteppableTemplate.class, true, false)));
+
+                // Use pre-built TemplateStep objects with typed payloads
+                TemplateStep<Object, Object> step1 = new TemplateStep<>();
+                step1.setApplyPayload(new TxPayload("apply1"));
+                TemplateStep<Object, Object> step2 = new TemplateStep<>();
+                step2.setApplyPayload(new NonTxPayload("apply2"));
+
+                builder.setId("test-id")
+                        .setFileName("test-file.yml")
+                        .setTemplateName("test-nontx-steppable-template")
+                        .setTransactionalFlag(null)
+                        .setSteps(Arrays.asList(step1, step2));
+                builder.setProfiles(Arrays.asList("test"));
+
+                AbstractTemplateLoadedChange<?, ?, ?> result = builder.build();
+
+                assertFalse(result.isTransactional());
+            }
+        }
+
+        @Test
+        @DisplayName("Should infer true when all steps support transactions")
+        void shouldInferTrueWhenAllStepsSupportTx() {
+            try (MockedStatic<ChangeTemplateManager> mockedTemplateManager = mockStatic(ChangeTemplateManager.class)) {
+                mockedTemplateManager.when(() -> ChangeTemplateManager.getTemplate("test-tx-steppable-template"))
+                        .thenReturn(Optional.of(new ChangeTemplateDefinition("test-tx-steppable-template", TxSteppableTemplate.class, true, false)));
+
+                TemplateStep<Object, Object> step1 = new TemplateStep<>();
+                step1.setApplyPayload(new TxPayload("apply1"));
+                TemplateStep<Object, Object> step2 = new TemplateStep<>();
+                step2.setApplyPayload(new TxPayload("apply2"));
+
+                builder.setId("test-id")
+                        .setFileName("test-file.yml")
+                        .setTemplateName("test-tx-steppable-template")
+                        .setTransactionalFlag(null)
+                        .setSteps(Arrays.asList(step1, step2));
+                builder.setProfiles(Arrays.asList("test"));
+
+                AbstractTemplateLoadedChange<?, ?, ?> result = builder.build();
+
+                assertTrue(result.isTransactional());
+            }
+        }
+
+        @Test
+        @DisplayName("Should infer true when all steps make no claim")
+        void shouldInferTrueWhenAllStepsMakeNoClaim() {
+            try (MockedStatic<ChangeTemplateManager> mockedTemplateManager = mockStatic(ChangeTemplateManager.class)) {
+                mockedTemplateManager.when(() -> ChangeTemplateManager.getTemplate("test-steppable-template"))
+                        .thenReturn(Optional.of(new ChangeTemplateDefinition("test-steppable-template", TestSteppableTemplate.class, true, false)));
+
+                List<Map<String, Object>> rawSteps = Arrays.asList(
+                        createStepMap("apply1", "rollback1"),
+                        createStepMap("apply2", "rollback2")
+                );
+
+                builder.setId("test-id")
+                        .setFileName("test-file.yml")
+                        .setTemplateName("test-steppable-template")
+                        .setTransactionalFlag(null)
+                        .setSteps(rawSteps);
+                builder.setProfiles(Arrays.asList("test"));
+
+                AbstractTemplateLoadedChange<?, ?, ?> result = builder.build();
+
+                assertTrue(result.isTransactional());
+            }
+        }
+
+        @Test
+        @DisplayName("Should infer true when mix of support and no claim")
+        void shouldInferTrueWhenMixOfSupportAndNoClaim() {
+            try (MockedStatic<ChangeTemplateManager> mockedTemplateManager = mockStatic(ChangeTemplateManager.class)) {
+                mockedTemplateManager.when(() -> ChangeTemplateManager.getTemplate("test-tx-steppable-template"))
+                        .thenReturn(Optional.of(new ChangeTemplateDefinition("test-tx-steppable-template", TxSteppableTemplate.class, true, false)));
+
+                // step1 has TxPayload (supportsTransactions=true), step2 uses raw String → TemplateString (no claim)
+                TemplateStep<Object, Object> step1 = new TemplateStep<>();
+                step1.setApplyPayload(new TxPayload("apply1"));
+                TemplateStep<Object, Object> step2 = new TemplateStep<>();
+                step2.setApplyPayload(new TxPayload("apply2"));
+
+                builder.setId("test-id")
+                        .setFileName("test-file.yml")
+                        .setTemplateName("test-tx-steppable-template")
+                        .setTransactionalFlag(null)
+                        .setSteps(Arrays.asList(step1, step2));
+                builder.setProfiles(Arrays.asList("test"));
+
+                AbstractTemplateLoadedChange<?, ?, ?> result = builder.build();
+
+                assertTrue(result.isTransactional());
+            }
+        }
+
+        @Test
+        @DisplayName("Should infer true when steps is empty")
+        void shouldInferTrueWhenStepsIsEmpty() {
+            try (MockedStatic<ChangeTemplateManager> mockedTemplateManager = mockStatic(ChangeTemplateManager.class)) {
+                mockedTemplateManager.when(() -> ChangeTemplateManager.getTemplate("test-steppable-template"))
+                        .thenReturn(Optional.of(new ChangeTemplateDefinition("test-steppable-template", TestSteppableTemplate.class, true, false)));
+
+                builder.setId("test-id")
+                        .setFileName("test-file.yml")
+                        .setTemplateName("test-steppable-template")
+                        .setTransactionalFlag(null)
+                        .setSteps(Collections.emptyList());
+                builder.setProfiles(Arrays.asList("test"));
+
+                AbstractTemplateLoadedChange<?, ?, ?> result = builder.build();
+
+                assertTrue(result.isTransactional());
+            }
+        }
+
+        @Test
+        @DisplayName("Should infer true when steps is null")
+        void shouldInferTrueWhenStepsIsNull() {
+            try (MockedStatic<ChangeTemplateManager> mockedTemplateManager = mockStatic(ChangeTemplateManager.class)) {
+                mockedTemplateManager.when(() -> ChangeTemplateManager.getTemplate("test-steppable-template"))
+                        .thenReturn(Optional.of(new ChangeTemplateDefinition("test-steppable-template", TestSteppableTemplate.class, true, false)));
+
+                builder.setId("test-id")
+                        .setFileName("test-file.yml")
+                        .setTemplateName("test-steppable-template")
+                        .setTransactionalFlag(null)
+                        .setSteps(null);
+                builder.setProfiles(Arrays.asList("test"));
+
+                AbstractTemplateLoadedChange<?, ?, ?> result = builder.build();
+
+                assertTrue(result.isTransactional());
+            }
+        }
+
+        @Test
+        @DisplayName("Should respect explicit true when step does not support transactions")
+        void shouldRespectExplicitTrueWhenStepDoesNotSupportTx() {
+            try (MockedStatic<ChangeTemplateManager> mockedTemplateManager = mockStatic(ChangeTemplateManager.class)) {
+                mockedTemplateManager.when(() -> ChangeTemplateManager.getTemplate("test-nontx-steppable-template"))
+                        .thenReturn(Optional.of(new ChangeTemplateDefinition("test-nontx-steppable-template", NonTxSteppableTemplate.class, true, false)));
+
+                TemplateStep<Object, Object> step1 = new TemplateStep<>();
+                step1.setApplyPayload(new NonTxPayload("apply1"));
+
+                builder.setId("test-id")
+                        .setFileName("test-file.yml")
+                        .setTemplateName("test-nontx-steppable-template")
+                        .setTransactionalFlag(true)
+                        .setSteps(Collections.singletonList(step1));
+                builder.setProfiles(Arrays.asList("test"));
+
+                AbstractTemplateLoadedChange<?, ?, ?> result = builder.build();
+
+                assertTrue(result.isTransactional());
             }
         }
     }

--- a/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/processor/MongockAnnotationProcessorPlugin.java
+++ b/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/processor/MongockAnnotationProcessorPlugin.java
@@ -107,7 +107,7 @@ public class MongockAnnotationProcessorPlugin implements AnnotationProcessorPlug
         builder.setOrder("00100");
         builder.setAuthor("flamingock-team");
         builder.setTargetSystem(new TargetSystemDescriptor(targetSystemId));
-        builder.setTransactional(true);
+        builder.setTransactionalFlag(true);
         builder.setSystem(true);
         builder.setRecovery(RecoveryDescriptor.getDefault());
 


### PR DESCRIPTION
When the user omits `transactional` in YAML, the builder now inspects
apply payloads' `TemplatePayloadInfo.getSupportsTransactions()` to
determine the correct value, instead of always defaulting to `true`.

- If **any** apply payload claims `supportsTransactions=false` → infer `false`
- Otherwise → infer `true` (all claim true, unclaimed, mix, or null/empty)
- Explicit YAML values (`transactional: true/false`) always take precedence

**Changes:**
- **TemplateLoadedTaskBuilder**: add `inferTransactionalFromPayloads()`,
  `resolveTransactional()`, and `resolveTransactionalFromSteps()` methods
  replacing the hardcoded `null → true` fallback
- **SimpleTemplateLoadedTaskBuilderTest**: add `NonTxPayload`, `TxPayload`,
  `NonTxTemplate`, `TxTemplate` test infrastructure and 6 inference tests
- **SteppableTemplateLoadedTaskBuilderTest**: add equivalent test
  infrastructure with steppable templates and 7 inference tests
