### PR TITLE
refactor(templates): introduce TemplateField hierarchy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -515,6 +515,7 @@ See `docs/TEMPLATES_EVOLUTION_PROPOSALS.md` for comprehensive proposals includin
 ## Commit Message Convention
 
 All commits must follow [Conventional Commits](https://www.conventionalcommits.org/) with a well-structured body suitable for changelog extraction from `git log`.
+Don't add co-authored by claude
 
 ### Format
 

--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/template/AbstractChangeTemplate.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/template/AbstractChangeTemplate.java
@@ -39,7 +39,7 @@ import java.util.Set;
  * @param <ROLLBACK_FIELD> rollback payload type
  * @see io.flamingock.api.annotations.ChangeTemplate
  */
-public abstract class AbstractChangeTemplate<SHARED_CONFIGURATION_FIELD extends TemplatePayload, APPLY_FIELD extends TemplatePayload, ROLLBACK_FIELD extends TemplatePayload> implements ChangeTemplate<SHARED_CONFIGURATION_FIELD, APPLY_FIELD, ROLLBACK_FIELD> {
+public abstract class AbstractChangeTemplate<SHARED_CONFIGURATION_FIELD extends TemplateField, APPLY_FIELD extends TemplatePayload, ROLLBACK_FIELD extends TemplatePayload> implements ChangeTemplate<SHARED_CONFIGURATION_FIELD, APPLY_FIELD, ROLLBACK_FIELD> {
 
     private final Class<SHARED_CONFIGURATION_FIELD> configurationClass;
     private final Class<APPLY_FIELD> applyPayloadClass;

--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/template/ChangeTemplate.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/template/ChangeTemplate.java
@@ -28,7 +28,7 @@ package io.flamingock.api.template;
  * @see AbstractChangeTemplate
  * @see io.flamingock.api.annotations.ChangeTemplate
  */
-public interface ChangeTemplate<SHARED_CONFIG_FIELD extends TemplatePayload, APPLY_FIELD extends TemplatePayload, ROLLBACK_FIELD extends TemplatePayload> extends ReflectionMetadataProvider {
+public interface ChangeTemplate<SHARED_CONFIG_FIELD extends TemplateField, APPLY_FIELD extends TemplatePayload, ROLLBACK_FIELD extends TemplatePayload> extends ReflectionMetadataProvider {
 
     void setChangeId(String changeId);
 

--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/template/TemplateField.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/template/TemplateField.java
@@ -18,19 +18,20 @@ package io.flamingock.api.template;
 import java.util.List;
 
 /**
- * Contract for template payload types (APPLY and ROLLBACK generics).
+ * Base contract for all template field types (configuration, apply, rollback).
  *
- * <p>Extends {@link TemplateField} to inherit structural validation, and adds
- * transactional metadata via {@link #getInfo()}. Configuration fields use
- * {@code TemplateField} directly since they have no transactional semantics.
+ * <p>Provides structural validation at pipeline load time, before any change executes.
+ * Configuration fields extend this directly, while apply/rollback payloads extend
+ * {@link TemplatePayload} which adds transactional metadata via {@code getInfo()}.
  */
-public interface TemplatePayload extends TemplateField {
+public interface TemplateField {
 
     /**
-     * Returns metadata about this payload so the framework can make
-     * centralized decisions based on payload characteristics.
+     * Validates this field using the supplied change-level context
+     * and returns any errors found.
      *
-     * @return payload info; never {@code null}
+     * @param context change-level metadata available during validation
+     * @return list of validation errors, empty if field is valid
      */
-    TemplatePayloadInfo getInfo();
+    List<TemplatePayloadValidationError> validate(TemplateValidationContext context);
 }

--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/template/wrappers/TemplateVoid.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/template/wrappers/TemplateVoid.java
@@ -24,12 +24,11 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * A {@link TemplatePayload} sentinel representing "no configuration needed".
+ * A {@link TemplatePayload} sentinel representing "no value needed".
  *
- * <p>Replaces {@code Void} as the CONFIG type parameter in templates that
- * have no shared configuration. Unlike {@code Void}, this class implements
- * {@code TemplatePayload}, satisfying the {@code CONFIG extends TemplatePayload}
- * bound on the template system.
+ * <p>Replaces {@code Void} as a type parameter in templates that have no shared
+ * configuration or no rollback. Implements {@code TemplatePayload} so it can be
+ * used in any template type parameter position (CONFIG, APPLY, or ROLLBACK).
  */
 public class TemplateVoid implements TemplatePayload {
 

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/AbstractTemplateExecutableTask.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/AbstractTemplateExecutableTask.java
@@ -16,6 +16,7 @@
 package io.flamingock.internal.core.task.executable;
 
 import io.flamingock.api.template.ChangeTemplate;
+import io.flamingock.api.template.TemplateField;
 import io.flamingock.api.template.TemplatePayload;
 import io.flamingock.api.template.wrappers.TemplateVoid;
 import io.flamingock.internal.common.core.recovery.action.ChangeAction;
@@ -36,7 +37,7 @@ import java.util.Arrays;
  * @param <ROLLBACK> the rollback payload type
  * @param <LOADED_CHANGE>        the type of template loaded change
  */
-public abstract class AbstractTemplateExecutableTask<CONFIG extends TemplatePayload, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload,
+public abstract class AbstractTemplateExecutableTask<CONFIG extends TemplateField, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload,
         LOADED_CHANGE extends AbstractTemplateLoadedChange<CONFIG, APPLY, ROLLBACK>> extends ReflectionExecutableTask<LOADED_CHANGE> {
     protected final Logger logger = FlamingockLoggerFactory.getLogger("TemplateExecutableChange");
 

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/SimpleTemplateExecutableTask.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/SimpleTemplateExecutableTask.java
@@ -16,6 +16,7 @@
 package io.flamingock.internal.core.task.executable;
 
 import io.flamingock.api.template.AbstractChangeTemplate;
+import io.flamingock.api.template.TemplateField;
 import io.flamingock.api.template.TemplatePayload;
 import io.flamingock.internal.common.core.error.ChangeExecutionException;
 import io.flamingock.internal.common.core.recovery.action.ChangeAction;
@@ -33,7 +34,7 @@ import java.lang.reflect.Method;
  * @param <ROLLBACK> the rollback payload type
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class SimpleTemplateExecutableTask<CONFIG extends TemplatePayload, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload>
+public class SimpleTemplateExecutableTask<CONFIG extends TemplateField, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload>
         extends AbstractTemplateExecutableTask<CONFIG, APPLY, ROLLBACK,
                 SimpleTemplateLoadedChange<CONFIG, APPLY, ROLLBACK>> {
 

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/SteppableTemplateExecutableTask.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/executable/SteppableTemplateExecutableTask.java
@@ -16,6 +16,7 @@
 package io.flamingock.internal.core.task.executable;
 
 import io.flamingock.api.template.AbstractChangeTemplate;
+import io.flamingock.api.template.TemplateField;
 import io.flamingock.api.template.TemplatePayload;
 import io.flamingock.api.template.TemplateStep;
 import io.flamingock.internal.common.core.error.ChangeExecutionException;
@@ -36,7 +37,7 @@ import java.util.List;
  * @param <ROLLBACK> the rollback payload type
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class SteppableTemplateExecutableTask<CONFIG extends TemplatePayload, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload>
+public class SteppableTemplateExecutableTask<CONFIG extends TemplateField, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload>
         extends AbstractTemplateExecutableTask<CONFIG, APPLY, ROLLBACK,
         MultiStepTemplateLoadedChange<CONFIG, APPLY, ROLLBACK>> {
 

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/AbstractTemplateLoadedChange.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/AbstractTemplateLoadedChange.java
@@ -18,6 +18,7 @@ package io.flamingock.internal.core.task.loaded;
 import io.flamingock.api.annotations.Apply;
 import io.flamingock.api.annotations.Rollback;
 import io.flamingock.api.template.ChangeTemplate;
+import io.flamingock.api.template.TemplateField;
 import io.flamingock.api.template.TemplatePayload;
 import io.flamingock.api.template.TemplateValidationContext;
 import io.flamingock.internal.common.core.error.validation.ValidationError;
@@ -43,7 +44,7 @@ import java.util.Optional;
  * @param <APPLY>    the apply payload type
  * @param <ROLLBACK> the rollback payload type
  */
-public abstract class AbstractTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload> extends AbstractLoadedChange {
+public abstract class AbstractTemplateLoadedChange<CONFIG extends TemplateField, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload> extends AbstractLoadedChange {
 
     protected static final Logger logger = FlamingockLoggerFactory.getLogger(AbstractTemplateLoadedChange.class);
 

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/MultiStepTemplateLoadedChange.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/MultiStepTemplateLoadedChange.java
@@ -16,6 +16,7 @@
 package io.flamingock.internal.core.task.loaded;
 
 import io.flamingock.api.template.AbstractChangeTemplate;
+import io.flamingock.api.template.TemplateField;
 import io.flamingock.api.template.TemplatePayload;
 import io.flamingock.api.template.TemplatePayloadValidationError;
 import io.flamingock.api.template.TemplateStep;
@@ -40,7 +41,7 @@ import java.util.List;
  * @param <APPLY>    the apply payload type
  * @param <ROLLBACK> the rollback payload type
  */
-public class MultiStepTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload>
+public class MultiStepTemplateLoadedChange<CONFIG extends TemplateField, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload>
         extends AbstractTemplateLoadedChange<CONFIG, APPLY, ROLLBACK> {
 
     private final List<TemplateStep<APPLY, ROLLBACK>> steps;

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/SimpleTemplateLoadedChange.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/SimpleTemplateLoadedChange.java
@@ -16,6 +16,7 @@
 package io.flamingock.internal.core.task.loaded;
 
 import io.flamingock.api.template.AbstractChangeTemplate;
+import io.flamingock.api.template.TemplateField;
 import io.flamingock.api.template.TemplatePayload;
 import io.flamingock.api.template.TemplatePayloadValidationError;
 import io.flamingock.api.template.TemplateValidationContext;
@@ -39,7 +40,7 @@ import java.util.List;
  * @param <APPLY>    the apply payload type
  * @param <ROLLBACK> the rollback payload type
  */
-public class SimpleTemplateLoadedChange<CONFIG extends TemplatePayload, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload>
+public class SimpleTemplateLoadedChange<CONFIG extends TemplateField, APPLY extends TemplatePayload, ROLLBACK extends TemplatePayload>
         extends AbstractTemplateLoadedChange<CONFIG, APPLY, ROLLBACK> {
 
     // Already converted to typed payload (no longer raw Object from YAML)

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/TemplateLoadedTaskBuilder.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/TemplateLoadedTaskBuilder.java
@@ -16,6 +16,7 @@
 package io.flamingock.internal.core.task.loaded;
 
 import io.flamingock.api.template.AbstractChangeTemplate;
+import io.flamingock.api.template.TemplateField;
 import io.flamingock.api.template.TemplatePayload;
 import io.flamingock.api.template.TemplateStep;
 import io.flamingock.api.template.wrappers.TemplateVoid;
@@ -212,7 +213,7 @@ public class TemplateLoadedTaskBuilder implements LoadedTaskBuilder<AbstractTemp
     @SuppressWarnings({"unchecked", "rawtypes"})
     private MultiStepTemplateLoadedChange getLoadedMultiStepTemplateChange(Class<? extends AbstractChangeTemplate> steppableTemplateClass, Constructor<?> constructor, boolean rollbackPayloadRequired) {
         List<TemplateStep<Object, Object>> convertedSteps = convertSteps(constructor, steps);// Convert apply/rollback to typed payloads at load time
-        TemplatePayload convertedConfig = convertConfiguration(constructor, configuration);
+        TemplateField convertedConfig = convertConfiguration(constructor, configuration);
         boolean resolvedTransactional = resolveTransactionalFromSteps(convertedSteps);
         return new MultiStepTemplateLoadedChange(
                 fileName,
@@ -237,7 +238,7 @@ public class TemplateLoadedTaskBuilder implements LoadedTaskBuilder<AbstractTemp
     @SuppressWarnings({"unchecked", "rawtypes"})
     private SimpleTemplateLoadedChange getLoadedSimpleTemplateChange(Class<? extends AbstractChangeTemplate> simpleTemplateClass, Constructor<?> constructor, boolean rollbackPayloadRequired) {
         Pair<Object, Object> convertedPayloads = convertPayloads(constructor, applyPayload, rollbackPayload);// Convert apply/rollback to typed payloads at load time
-        TemplatePayload convertedConfig = convertConfiguration(constructor, configuration);
+        TemplateField convertedConfig = convertConfiguration(constructor, configuration);
         boolean resolvedTransactional = resolveTransactional((TemplatePayload) convertedPayloads.getFirst());
         return new SimpleTemplateLoadedChange(
                 fileName,
@@ -350,7 +351,7 @@ public class TemplateLoadedTaskBuilder implements LoadedTaskBuilder<AbstractTemp
      * Converts raw configuration data to typed TemplatePayload at load time.
      * Returns null if no configuration is needed (TemplateVoid config or null data).
      */
-    private TemplatePayload convertConfiguration(Constructor<?> constructor, Object configData) {
+    private TemplateField convertConfiguration(Constructor<?> constructor, Object configData) {
         // Instantiate template temporarily to get config class
         AbstractChangeTemplate<?, ?, ?> templateInstance;
         try {
@@ -365,7 +366,7 @@ public class TemplateLoadedTaskBuilder implements LoadedTaskBuilder<AbstractTemp
             return null;
         }
 
-        return (TemplatePayload) FileUtil.convertToType(configClass, configData);
+        return (TemplateField) FileUtil.convertToType(configClass, configData);
     }
 
     /**


### PR DESCRIPTION
- Add **TemplateField** interface with `validate()` as base
  for all template field types
- **TemplatePayload** extends TemplateField, adds `getInfo()`
  for transactional metadata
- Relax SHARED_CONFIG bound from `TemplatePayload` to
  `TemplateField` across the template hierarchy
- Config fields now need only validation, not tx semantics
- Binary-compatible: existing TemplatePayload impls still
  satisfy the relaxed bound
