### PR TITLE
refactor(templates): introduce @ApplyTemplate and @RollbackTemplate annotations

### DIFF
--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/annotations/ApplyTemplate.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/annotations/ApplyTemplate.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Flamingock (https://www.flamingock.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.flamingock.api.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks the method that applies a template-based change to the target system.
+ * This method contains the forward change logic that evolves your system state.
+ *
+ * <p>The method can accept dependency-injected parameters from the Flamingock context,
+ * including database connections, repositories, and custom dependencies.
+ *
+ * <p>This annotation is specifically for use in {@link ChangeTemplate} classes.
+ * For code-based {@link Change} classes, use {@link Apply} instead.
+ *
+ * @see ChangeTemplate
+ * @see RollbackTemplate
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApplyTemplate {
+
+}

--- a/core/flamingock-core-api/src/main/java/io/flamingock/api/annotations/RollbackTemplate.java
+++ b/core/flamingock-core-api/src/main/java/io/flamingock/api/annotations/RollbackTemplate.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Flamingock (https://www.flamingock.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.flamingock.api.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks the method that rolls back a template-based change in case of failure or manual reversion.
+ * This method should undo the operations performed by the corresponding {@link ApplyTemplate} method.
+ *
+ * <p>Rollback methods are optional but recommended for production systems to ensure
+ * safe change reversibility. They receive the same dependency injection as ApplyTemplate methods.
+ *
+ * <p>This annotation is specifically for use in {@link ChangeTemplate} classes.
+ * For code-based {@link Change} classes, use {@link Rollback} instead.
+ *
+ * @see ChangeTemplate
+ * @see ApplyTemplate
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RollbackTemplate {
+
+}

--- a/core/flamingock-core-api/src/test/java/io/flamingock/api/template/AbstractChangeTemplateReflectiveClassesTest.java
+++ b/core/flamingock-core-api/src/test/java/io/flamingock/api/template/AbstractChangeTemplateReflectiveClassesTest.java
@@ -15,9 +15,9 @@
  */
 package io.flamingock.api.template;
 
-import io.flamingock.api.annotations.Apply;
+import io.flamingock.api.annotations.ApplyTemplate;
 import io.flamingock.api.annotations.ChangeTemplate;
-import io.flamingock.api.annotations.Rollback;
+import io.flamingock.api.annotations.RollbackTemplate;
 import io.flamingock.api.template.wrappers.TemplateString;
 import io.flamingock.api.template.wrappers.TemplateVoid;
 import org.junit.jupiter.api.DisplayName;
@@ -95,12 +95,12 @@ class AbstractChangeTemplateReflectiveClassesTest {
             super();
         }
 
-        @Apply
+        @ApplyTemplate
         public void apply() {
             // Test implementation
         }
 
-        @Rollback
+        @RollbackTemplate
         public void rollback() {
         }
     }
@@ -114,12 +114,12 @@ class AbstractChangeTemplateReflectiveClassesTest {
             super(AdditionalClass.class, AnotherAdditionalClass.class);
         }
 
-        @Apply
+        @ApplyTemplate
         public void apply() {
             // Test implementation
         }
 
-        @Rollback
+        @RollbackTemplate
         public void rollback() {
         }
     }
@@ -133,12 +133,12 @@ class AbstractChangeTemplateReflectiveClassesTest {
             super();
         }
 
-        @Apply
+        @ApplyTemplate
         public void apply() {
             // Test implementation
         }
 
-        @Rollback
+        @RollbackTemplate
         public void rollback() {
         }
     }

--- a/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/template/ChangeTemplateManager.java
+++ b/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/template/ChangeTemplateManager.java
@@ -15,7 +15,7 @@
  */
 package io.flamingock.internal.common.core.template;
 
-import io.flamingock.api.annotations.Rollback;
+import io.flamingock.api.annotations.RollbackTemplate;
 import io.flamingock.api.template.ChangeTemplate;
 import io.flamingock.internal.common.core.error.FlamingockException;
 import io.flamingock.internal.util.ReflectionUtil;
@@ -179,9 +179,9 @@ public final class ChangeTemplateManager {
                     "Template class '%s' has a blank @ChangeTemplate id. The id must be a non-empty string",
                     templateClass.getSimpleName()));
         }
-        if (!ReflectionUtil.findFirstAnnotatedMethod(templateClass, Rollback.class).isPresent()) {
+        if (!ReflectionUtil.findFirstAnnotatedMethod(templateClass, RollbackTemplate.class).isPresent()) {
             throw new FlamingockException(String.format(
-                    "Template class '%s' is missing required @Rollback method",
+                    "Template class '%s' is missing required @RollbackTemplate method",
                     templateClass.getSimpleName()));
         }
         return new ChangeTemplateDefinition(id, templateClass, annotation.multiStep(), annotation.rollbackPayloadRequired());

--- a/core/flamingock-core-commons/src/test/java/io/flamingock/internal/common/core/template/ChangeTemplateManagerTest.java
+++ b/core/flamingock-core-commons/src/test/java/io/flamingock/internal/common/core/template/ChangeTemplateManagerTest.java
@@ -15,9 +15,9 @@
  */
 package io.flamingock.internal.common.core.template;
 
-import io.flamingock.api.annotations.Apply;
+import io.flamingock.api.annotations.ApplyTemplate;
 import io.flamingock.api.annotations.ChangeTemplate;
-import io.flamingock.api.annotations.Rollback;
+import io.flamingock.api.annotations.RollbackTemplate;
 import io.flamingock.api.template.AbstractChangeTemplate;
 import io.flamingock.api.template.wrappers.TemplateString;
 import io.flamingock.api.template.wrappers.TemplateVoid;
@@ -37,11 +37,11 @@ class ChangeTemplateManagerTest {
             super();
         }
 
-        @Apply
+        @ApplyTemplate
         public void apply() {
         }
 
-        @Rollback
+        @RollbackTemplate
         public void rollback() {
         }
     }
@@ -52,11 +52,11 @@ class ChangeTemplateManagerTest {
             super();
         }
 
-        @Apply
+        @ApplyTemplate
         public void apply() {
         }
 
-        @Rollback
+        @RollbackTemplate
         public void rollback() {
         }
     }
@@ -66,7 +66,7 @@ class ChangeTemplateManagerTest {
             super();
         }
 
-        @Apply
+        @ApplyTemplate
         public void apply() {
         }
     }
@@ -120,11 +120,11 @@ class ChangeTemplateManagerTest {
             super();
         }
 
-        @Apply
+        @ApplyTemplate
         public void apply() {
         }
 
-        @Rollback
+        @RollbackTemplate
         public void rollback() {
         }
     }
@@ -147,18 +147,18 @@ class ChangeTemplateManagerTest {
             super();
         }
 
-        @Apply
+        @ApplyTemplate
         public void apply() {
         }
     }
 
     @Test
-    @DisplayName("addTemplate with class missing @Rollback method should throw FlamingockException")
+    @DisplayName("addTemplate with class missing @RollbackTemplate method should throw FlamingockException")
     void addTemplateWithMissingRollbackMethodShouldThrow() {
         FlamingockException exception = assertThrows(FlamingockException.class,
                 () -> ChangeTemplateManager.addTemplate(TemplateWithoutRollback.class));
 
-        assertTrue(exception.getMessage().contains("missing required @Rollback method"));
+        assertTrue(exception.getMessage().contains("missing required @RollbackTemplate method"));
         assertTrue(exception.getMessage().contains("TemplateWithoutRollback"));
     }
 }

--- a/core/flamingock-core-commons/src/test/java/io/flamingock/internal/common/core/template/TemplateValidatorTest.java
+++ b/core/flamingock-core-commons/src/test/java/io/flamingock/internal/common/core/template/TemplateValidatorTest.java
@@ -15,9 +15,9 @@
  */
 package io.flamingock.internal.common.core.template;
 
-import io.flamingock.api.annotations.Apply;
+import io.flamingock.api.annotations.ApplyTemplate;
 import io.flamingock.api.annotations.ChangeTemplate;
-import io.flamingock.api.annotations.Rollback;
+import io.flamingock.api.annotations.RollbackTemplate;
 import io.flamingock.api.template.AbstractChangeTemplate;
 import io.flamingock.api.template.wrappers.TemplateString;
 import io.flamingock.api.template.wrappers.TemplateVoid;
@@ -47,12 +47,12 @@ class TemplateValidatorTest {
             super();
         }
 
-        @Apply
+        @ApplyTemplate
         public void apply() {
             // Test implementation
         }
 
-        @Rollback
+        @RollbackTemplate
         public void rollback() {
         }
     }
@@ -64,12 +64,12 @@ class TemplateValidatorTest {
             super();
         }
 
-        @Apply
+        @ApplyTemplate
         public void apply() {
             // Test implementation
         }
 
-        @Rollback
+        @RollbackTemplate
         public void rollback() {
         }
     }

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/AbstractTemplateLoadedChange.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/task/loaded/AbstractTemplateLoadedChange.java
@@ -15,8 +15,8 @@
  */
 package io.flamingock.internal.core.task.loaded;
 
-import io.flamingock.api.annotations.Apply;
-import io.flamingock.api.annotations.Rollback;
+import io.flamingock.api.annotations.ApplyTemplate;
+import io.flamingock.api.annotations.RollbackTemplate;
 import io.flamingock.api.template.ChangeTemplate;
 import io.flamingock.api.template.TemplateField;
 import io.flamingock.api.template.TemplatePayload;
@@ -89,16 +89,16 @@ public abstract class AbstractTemplateLoadedChange<CONFIG extends TemplateField,
 
     @Override
     public Method getApplyMethod() {
-        return ReflectionUtil.findFirstAnnotatedMethod(getImplementationClass(), Apply.class)
+        return ReflectionUtil.findFirstAnnotatedMethod(getImplementationClass(), ApplyTemplate.class)
                 .orElseThrow(() -> new IllegalArgumentException(String.format(
                         "Templated[%s] without %s method",
                         getSource(),
-                        Apply.class.getSimpleName())));
+                        ApplyTemplate.class.getSimpleName())));
     }
 
     @Override
     public Optional<Method> getRollbackMethod() {
-        return ReflectionUtil.findFirstAnnotatedMethod(getImplementationClass(), Rollback.class);
+        return ReflectionUtil.findFirstAnnotatedMethod(getImplementationClass(), RollbackTemplate.class);
     }
 
     @Override

--- a/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/executable/SteppableTemplateExecutableTaskTest.java
+++ b/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/executable/SteppableTemplateExecutableTaskTest.java
@@ -15,9 +15,9 @@
  */
 package io.flamingock.internal.core.task.executable;
 
-import io.flamingock.api.annotations.Apply;
+import io.flamingock.api.annotations.ApplyTemplate;
 import io.flamingock.api.annotations.ChangeTemplate;
-import io.flamingock.api.annotations.Rollback;
+import io.flamingock.api.annotations.RollbackTemplate;
 import io.flamingock.api.template.AbstractChangeTemplate;
 import io.flamingock.api.template.TemplateStep;
 import io.flamingock.api.template.wrappers.TemplateString;
@@ -67,7 +67,7 @@ class SteppableTemplateExecutableTaskTest {
             super();
         }
 
-        @Apply
+        @ApplyTemplate
         public void apply() {
             if (shouldFailOnApply && appliedPayloads.size() == failAtStep) {
                 throw new RuntimeException("Simulated apply failure at step " + failAtStep);
@@ -75,7 +75,7 @@ class SteppableTemplateExecutableTaskTest {
             appliedPayloads.add(applyPayload.getValue());
         }
 
-        @Rollback
+        @RollbackTemplate
         public void rollback() {
             if (shouldFailOnRollback) {
                 throw new RuntimeException("Simulated rollback failure");
@@ -94,7 +94,7 @@ class SteppableTemplateExecutableTaskTest {
             super();
         }
 
-        @Apply
+        @ApplyTemplate
         public void apply() {
             if (shouldFailOnApply && appliedPayloads.size() == failAtStep) {
                 throw new RuntimeException("Simulated apply failure at step " + failAtStep);
@@ -102,7 +102,7 @@ class SteppableTemplateExecutableTaskTest {
             appliedPayloads.add(applyPayload.getValue());
         }
 
-        @Rollback
+        @RollbackTemplate
         public void rollback() {
         }
     }

--- a/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/PayloadTransactionSupportValidationTest.java
+++ b/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/PayloadTransactionSupportValidationTest.java
@@ -15,8 +15,8 @@
  */
 package io.flamingock.internal.core.task.loaded;
 
-import io.flamingock.api.annotations.Apply;
-import io.flamingock.api.annotations.Rollback;
+import io.flamingock.api.annotations.ApplyTemplate;
+import io.flamingock.api.annotations.RollbackTemplate;
 import io.flamingock.api.template.AbstractChangeTemplate;
 import io.flamingock.api.template.TemplatePayload;
 import io.flamingock.api.template.TemplatePayloadInfo;
@@ -88,11 +88,11 @@ class PayloadTransactionSupportValidationTest {
     // ── Dummy template (never instantiated — only .class is used) ───────
 
     static class DummyTemplate extends AbstractChangeTemplate<TemplateVoid, TemplateString, TemplateString> {
-        @Apply
+        @ApplyTemplate
         public void apply() {
         }
 
-        @Rollback
+        @RollbackTemplate
         public void rollback() {
         }
     }

--- a/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/SimpleTemplateLoadedTaskBuilderTest.java
+++ b/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/SimpleTemplateLoadedTaskBuilderTest.java
@@ -20,7 +20,7 @@ import io.flamingock.internal.common.core.error.validation.ValidationError;
 import io.flamingock.internal.common.core.template.ChangeTemplateDefinition;
 import io.flamingock.internal.common.core.template.ChangeTemplateManager;
 import io.flamingock.api.annotations.ChangeTemplate;
-import io.flamingock.api.annotations.Rollback;
+import io.flamingock.api.annotations.RollbackTemplate;
 import io.flamingock.api.template.AbstractChangeTemplate;
 import io.flamingock.api.template.TemplatePayload;
 import io.flamingock.api.template.TemplatePayloadInfo;
@@ -28,7 +28,7 @@ import io.flamingock.api.template.TemplatePayloadValidationError;
 import io.flamingock.api.template.TemplateValidationContext;
 import io.flamingock.api.template.wrappers.TemplateString;
 import io.flamingock.api.template.wrappers.TemplateVoid;
-import io.flamingock.api.annotations.Apply;
+import io.flamingock.api.annotations.ApplyTemplate;
 import io.flamingock.internal.core.pipeline.loaded.stage.StageValidationContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -56,12 +56,12 @@ class SimpleTemplateLoadedTaskBuilderTest {
             super();
         }
 
-        @Apply
+        @ApplyTemplate
         public void apply(Object config, Object execution, Object context) {
             // Test implementation
         }
 
-        @Rollback
+        @RollbackTemplate
         public void rollback() {
         }
     }
@@ -120,10 +120,10 @@ class SimpleTemplateLoadedTaskBuilderTest {
     public static class NonTxTemplate extends AbstractChangeTemplate<TemplateVoid, NonTxPayload, TemplateString> {
         public NonTxTemplate() { super(); }
 
-        @Apply
+        @ApplyTemplate
         public void apply() {}
 
-        @Rollback
+        @RollbackTemplate
         public void rollback() {}
     }
 
@@ -131,10 +131,10 @@ class SimpleTemplateLoadedTaskBuilderTest {
     public static class TxTemplate extends AbstractChangeTemplate<TemplateVoid, TxPayload, TemplateString> {
         public TxTemplate() { super(); }
 
-        @Apply
+        @ApplyTemplate
         public void apply() {}
 
-        @Rollback
+        @RollbackTemplate
         public void rollback() {}
     }
 

--- a/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/SteppableTemplateLoadedTaskBuilderTest.java
+++ b/core/flamingock-core/src/test/java/io/flamingock/internal/core/task/loaded/SteppableTemplateLoadedTaskBuilderTest.java
@@ -15,9 +15,9 @@
  */
 package io.flamingock.internal.core.task.loaded;
 
-import io.flamingock.api.annotations.Apply;
+import io.flamingock.api.annotations.ApplyTemplate;
 import io.flamingock.api.annotations.ChangeTemplate;
-import io.flamingock.api.annotations.Rollback;
+import io.flamingock.api.annotations.RollbackTemplate;
 import io.flamingock.api.template.AbstractChangeTemplate;
 import io.flamingock.api.template.TemplatePayload;
 import io.flamingock.api.template.TemplatePayloadInfo;
@@ -61,12 +61,12 @@ class SteppableTemplateLoadedTaskBuilderTest {
             super();
         }
 
-        @Apply
+        @ApplyTemplate
         public void apply() {
             // Test implementation - iterates through steps
         }
 
-        @Rollback
+        @RollbackTemplate
         public void rollback() {
         }
     }
@@ -79,12 +79,12 @@ class SteppableTemplateLoadedTaskBuilderTest {
             super();
         }
 
-        @Apply
+        @ApplyTemplate
         public void apply() {
             // Test implementation
         }
 
-        @Rollback
+        @RollbackTemplate
         public void rollback() {
         }
     }
@@ -143,10 +143,10 @@ class SteppableTemplateLoadedTaskBuilderTest {
     public static class NonTxSteppableTemplate extends AbstractChangeTemplate<TemplateVoid, NonTxPayload, TemplateString> {
         public NonTxSteppableTemplate() { super(); }
 
-        @Apply
+        @ApplyTemplate
         public void apply() {}
 
-        @Rollback
+        @RollbackTemplate
         public void rollback() {}
     }
 
@@ -154,10 +154,10 @@ class SteppableTemplateLoadedTaskBuilderTest {
     public static class TxSteppableTemplate extends AbstractChangeTemplate<TemplateVoid, TxPayload, TemplateString> {
         public TxSteppableTemplate() { super(); }
 
-        @Apply
+        @ApplyTemplate
         public void apply() {}
 
-        @Rollback
+        @RollbackTemplate
         public void rollback() {}
     }
 

--- a/platform-plugins/flamingock-springboot-integration/src/test/java/io/flamingock/springboot/SpringProfileFilterTemplateTaskTest.java
+++ b/platform-plugins/flamingock-springboot-integration/src/test/java/io/flamingock/springboot/SpringProfileFilterTemplateTaskTest.java
@@ -17,6 +17,7 @@ package io.flamingock.springboot;
 
 import io.flamingock.api.annotations.Change;
 import io.flamingock.api.annotations.ChangeTemplate;
+import io.flamingock.api.annotations.RollbackTemplate;
 import io.flamingock.internal.common.core.template.ChangeTemplateFileContent;
 import io.flamingock.internal.common.core.task.RecoveryDescriptor;
 import io.flamingock.api.template.AbstractChangeTemplate;
@@ -135,7 +136,7 @@ class SpringProfileFilterTemplateTaskTest {
             super();
         }
 
-        @io.flamingock.api.annotations.Rollback
+        @RollbackTemplate
         public void rollback() {
         }
     }


### PR DESCRIPTION
- Create **@ApplyTemplate** and **@RollbackTemplate** as template-specific annotations, mirroring `@Apply` and `@Rollback` but dedicated to `@ChangeTemplate` classes
- Update **AbstractTemplateLoadedChange** to look up methods via the new annotations instead of `@Apply`/`@Rollback`
- Update **ChangeTemplateManager** validation to require `@RollbackTemplate` on template classes
- Migrate all test template classes across `flamingock-core-api`, `flamingock-core`, `flamingock-core-commons`, and `flamingock-springboot-integration` to use the new annotations

This is step 1 toward extracting a self-contained `flamingock-template-api` module. Code-based `@Change` classes continue to use `@Apply`/`@Rollback` unchanged.
