### PR TITLE
839 template storing standardcode when is template

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Java
         uses: graalvm/setup-graalvm@v1
@@ -19,3 +19,12 @@ jobs:
         run: |
           ./gradlew clean build \
             -Psql.test.dialects=mysql
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: |
+            **/build/reports/tests/**
+            **/build/test-results/**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,19 @@ jobs:
       FLAMINGOCK_JRELEASER_GPG_SECRET_KEY: ${{ secrets.FLAMINGOCK_JRELEASER_GPG_SECRET_KEY }}
       FLAMINGOCK_JRELEASER_GPG_PASSPHRASE: ${{ secrets.FLAMINGOCK_JRELEASER_GPG_PASSPHRASE }}
 
+  flamingock-template-api:
+    needs: [ build ]
+    uses: ./.github/workflows/module-release-graalvm.yml
+    with:
+      module: flamingock-template-api
+    secrets:
+      FLAMINGOCK_JRELEASER_GITHUB_TOKEN: ${{ secrets.FLAMINGOCK_JRELEASER_GITHUB_TOKEN }}
+      FLAMINGOCK_JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.FLAMINGOCK_JRELEASER_MAVENCENTRAL_USERNAME }}
+      FLAMINGOCK_JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.FLAMINGOCK_JRELEASER_MAVENCENTRAL_PASSWORD }}
+      FLAMINGOCK_JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.FLAMINGOCK_JRELEASER_GPG_PUBLIC_KEY }}
+      FLAMINGOCK_JRELEASER_GPG_SECRET_KEY: ${{ secrets.FLAMINGOCK_JRELEASER_GPG_SECRET_KEY }}
+      FLAMINGOCK_JRELEASER_GPG_PASSPHRASE: ${{ secrets.FLAMINGOCK_JRELEASER_GPG_PASSPHRASE }}
+
   flamingock-test-support:
     needs: [ build ]
     uses: ./.github/workflows/module-release-graalvm.yml
@@ -544,6 +557,7 @@ jobs:
       flamingock-core,
       flamingock-core-commons,
       flamingock-core-api,
+      flamingock-template-api,
       flamingock-processor,
       flamingock-graalvm,
       flamingock-cloud,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 
 allprojects {
     group = "io.flamingock"
-    version = "1.2.0-SNAPSHOT"
+    version = "1.2.0-beta.1"
 
     repositories {
         mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 
 allprojects {
     group = "io.flamingock"
-    version = "1.2.0-beta.1"
+    version = "1.2.0-beta.2"
 
     repositories {
         mavenCentral()

--- a/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/metadata/Constants.java
+++ b/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/metadata/Constants.java
@@ -23,6 +23,7 @@ public final class Constants {
 
     public static final String DEFAULT_MONGOCK_ORIGIN = "mongockChangeLog";
 
+    public static final String MONGOCK_IMPORT_SKIP_PROPERTY_KEY = "internal.mongock.import.skip";
     public static final String MONGOCK_IMPORT_ORIGIN_PROPERTY_KEY = "internal.mongock.import.origin";
     public static final String MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY = "internal.mongock.import.emptyOriginAllowed";
 

--- a/core/flamingock-core/src/main/java/io/flamingock/internal/core/external/store/audit/domain/AuditContextBundle.java
+++ b/core/flamingock-core/src/main/java/io/flamingock/internal/core/external/store/audit/domain/AuditContextBundle.java
@@ -21,10 +21,12 @@ import io.flamingock.internal.common.core.audit.AuditEntry;
 import io.flamingock.internal.common.cloud.vo.TargetSystemAuditMarkType;
 import io.flamingock.internal.core.pipeline.execution.ExecutionContext;
 import io.flamingock.internal.core.task.loaded.AbstractLoadedTask;
+import io.flamingock.internal.core.task.loaded.AbstractTemplateLoadedChange;
 
 import static io.flamingock.internal.common.core.audit.AuditEntry.ChangeType.MONGOCK_BEFORE;
 import static io.flamingock.internal.common.core.audit.AuditEntry.ChangeType.MONGOCK_EXECUTION;
 import static io.flamingock.internal.common.core.audit.AuditEntry.ChangeType.STANDARD_CODE;
+import static io.flamingock.internal.common.core.audit.AuditEntry.ChangeType.STANDARD_TEMPLATE;
 
 public abstract class AuditContextBundle {
 
@@ -132,12 +134,12 @@ public abstract class AuditContextBundle {
 
     private AuditEntry.ChangeType getChangeType() {
         if(changeDescriptor.isLegacy()) {
-            //TODO improve the way we retrieve mongock before
             return changeDescriptor.getId().endsWith("_before")
                     ? MONGOCK_BEFORE
                     : MONGOCK_EXECUTION;
+        } else if(changeDescriptor instanceof AbstractTemplateLoadedChange) {
+            return STANDARD_TEMPLATE;
         } else {
-            //TODO update this when template is released
             return STANDARD_CODE;
         }
     }

--- a/core/flamingock-core/src/test/java/io/flamingock/internal/core/external/store/audit/domain/AuditContextBundleChangeTypeTest.java
+++ b/core/flamingock-core/src/test/java/io/flamingock/internal/core/external/store/audit/domain/AuditContextBundleChangeTypeTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 Flamingock (https://www.flamingock.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.flamingock.internal.core.external.store.audit.domain;
+
+import io.flamingock.internal.common.core.audit.AuditEntry;
+import io.flamingock.internal.common.core.audit.AuditTxType;
+import io.flamingock.internal.common.core.task.RecoveryDescriptor;
+import io.flamingock.internal.core.pipeline.execution.ExecutionContext;
+import io.flamingock.internal.core.task.executable.ExecutableTask;
+import io.flamingock.internal.core.task.loaded.AbstractLoadedTask;
+import io.flamingock.internal.core.task.loaded.CodeLoadedChange;
+import io.flamingock.internal.core.task.loaded.SimpleTemplateLoadedChange;
+import io.flamingock.internal.core.task.navigation.step.StartStep;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AuditContextBundleChangeTypeTest {
+
+    @Test
+    void toAuditEntry_shouldReturnStandardCode_whenCodeLoadedChange() {
+        CodeLoadedChange loadedChange = mockCodeLoadedChange("change-001", false);
+        AuditEntry entry = buildAuditEntry(loadedChange);
+        assertEquals(AuditEntry.ChangeType.STANDARD_CODE, entry.getType());
+    }
+
+    @Test
+    void toAuditEntry_shouldReturnStandardTemplate_whenTemplateLoadedChange() {
+        SimpleTemplateLoadedChange loadedChange = mockTemplateLoadedChange("change-002");
+        AuditEntry entry = buildAuditEntry(loadedChange);
+        assertEquals(AuditEntry.ChangeType.STANDARD_TEMPLATE, entry.getType());
+    }
+
+    @Test
+    void toAuditEntry_shouldReturnMongockExecution_whenLegacyChange() {
+        CodeLoadedChange loadedChange = mockCodeLoadedChange("legacy-change", true);
+        AuditEntry entry = buildAuditEntry(loadedChange);
+        assertEquals(AuditEntry.ChangeType.MONGOCK_EXECUTION, entry.getType());
+    }
+
+    private AuditEntry buildAuditEntry(AbstractLoadedTask loadedChange) {
+        ExecutionContext executionContext = new ExecutionContext("exec-1", "localhost", Collections.emptyMap());
+
+        ExecutableTask executableTask = mock(ExecutableTask.class);
+        when(executableTask.getApplyMethodName()).thenReturn("apply");
+        when(executableTask.getStageName()).thenReturn("stage-1");
+
+        StartStep startStep = new StartStep(executableTask);
+        RuntimeContext runtimeContext = RuntimeContext.builder()
+                .setStartStep(startStep)
+                .setAppliedAt(LocalDateTime.now())
+                .build();
+
+        ExecutionAuditContextBundle bundle = new ExecutionAuditContextBundle(
+                loadedChange,
+                executionContext,
+                runtimeContext,
+                AuditTxType.NON_TX,
+                "target-system-1"
+        );
+
+        return bundle.toAuditEntry();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static CodeLoadedChange mockCodeLoadedChange(String id, boolean legacy) {
+        CodeLoadedChange change = mock(CodeLoadedChange.class);
+        when(change.getId()).thenReturn(id);
+        when(change.getAuthor()).thenReturn("test-author");
+        when(change.getSource()).thenReturn("TestChangeClass");
+        when(change.isSystem()).thenReturn(false);
+        when(change.isLegacy()).thenReturn(legacy);
+        when(change.getOrder()).thenReturn(Optional.of("001"));
+        when(change.getRecovery()).thenReturn(RecoveryDescriptor.getDefault());
+        when(change.isTransactional()).thenReturn(true);
+        return change;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static SimpleTemplateLoadedChange mockTemplateLoadedChange(String id) {
+        SimpleTemplateLoadedChange change = mock(SimpleTemplateLoadedChange.class);
+        when(change.getId()).thenReturn(id);
+        when(change.getAuthor()).thenReturn("test-author");
+        when(change.getSource()).thenReturn("template-change.yaml");
+        when(change.isSystem()).thenReturn(false);
+        when(change.isLegacy()).thenReturn(false);
+        when(change.getOrder()).thenReturn(Optional.of("002"));
+        when(change.getRecovery()).thenReturn(RecoveryDescriptor.getDefault());
+        when(change.isTransactional()).thenReturn(true);
+        return change;
+    }
+}

--- a/core/flamingock-graalvm/src/main/java/io/flamingock/graalvm/RegistrationFeature.java
+++ b/core/flamingock-graalvm/src/main/java/io/flamingock/graalvm/RegistrationFeature.java
@@ -17,7 +17,11 @@ package io.flamingock.graalvm;
 
 import io.flamingock.api.template.AbstractChangeTemplate;
 import io.flamingock.api.template.ChangeTemplate;
+import io.flamingock.api.template.TemplateField;
+import io.flamingock.api.template.TemplatePayload;
 import io.flamingock.api.template.TemplateStep;
+import io.flamingock.api.template.wrappers.TemplateString;
+import io.flamingock.api.template.wrappers.TemplateVoid;
 import io.flamingock.internal.common.core.metadata.FlamingockMetadata;
 import io.flamingock.internal.common.core.preview.*;
 import io.flamingock.internal.common.core.task.AbstractTaskDescriptor;
@@ -150,6 +154,10 @@ public class RegistrationFeature implements Feature {
         registerClassForReflection(ChangeTemplate.class);
         registerClassForReflection(AbstractChangeTemplate.class);
         registerClassForReflection(TemplateStep.class);
+        registerClassForReflection(TemplateField.class);
+        registerClassForReflection(TemplatePayload.class);
+        registerClassForReflection(TemplateString.class);
+        registerClassForReflection(TemplateVoid.class);
         ChangeTemplateManager.getRawTemplates().forEach(template -> {
             registerClassForReflection(template.getClass());
             template.getReflectiveClasses().forEach(RegistrationFeature::registerClassForReflection);

--- a/legacy/mongock-importer-couchbase/src/test/java/io/flamingock/importer/mongock/couchbase/CouchbaseImporterTest.java
+++ b/legacy/mongock-importer-couchbase/src/test/java/io/flamingock/importer/mongock/couchbase/CouchbaseImporterTest.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
 
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_ORIGIN_PROPERTY_KEY;
+import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_SKIP_PROPERTY_KEY;
 import static io.flamingock.internal.util.constants.AuditEntryFieldConstants.KEY_CREATED_AT;
 import static io.flamingock.internal.util.constants.AuditEntryFieldConstants.KEY_STATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -65,6 +66,9 @@ public class CouchbaseImporterTest {
     public static final String MONGOCK_BUCKET_NAME = "test";
     public static final String MONGOCK_SCOPE_NAME = CollectionIdentifier.DEFAULT_SCOPE;
     public static final String MONGOCK_COLLECTION_NAME = CollectionIdentifier.DEFAULT_COLLECTION;
+
+    public static final String CUSTOM_MONGOCK_ORIGIN_SCOPE = "mongockCustomScope";
+    public static final String CUSTOM_MONGOCK_ORIGIN_COLLECTION = "mongockCustomOriginCollection";
 
 
     @Container
@@ -101,7 +105,15 @@ public class CouchbaseImporterTest {
     @AfterEach
     void cleanUp() {
         CouchbaseCollectionHelper.deleteAllDocuments(cluster, FLAMINGOCK_BUCKET_NAME, FLAMINGOCK_SCOPE_NAME, FLAMINGOCK_COLLECTION_NAME);
+        CouchbaseCollectionHelper.waitUntilEmpty(cluster, FLAMINGOCK_BUCKET_NAME, FLAMINGOCK_SCOPE_NAME, FLAMINGOCK_COLLECTION_NAME, Duration.ofSeconds(10));
+
         CouchbaseCollectionHelper.deleteAllDocuments(cluster, MONGOCK_BUCKET_NAME, MONGOCK_SCOPE_NAME, MONGOCK_COLLECTION_NAME);
+        CouchbaseCollectionHelper.waitUntilEmpty(cluster, MONGOCK_BUCKET_NAME, MONGOCK_SCOPE_NAME, MONGOCK_COLLECTION_NAME, Duration.ofSeconds(10));
+
+        if (CouchbaseCollectionHelper.collectionExists(cluster, MONGOCK_BUCKET_NAME, CUSTOM_MONGOCK_ORIGIN_SCOPE, CUSTOM_MONGOCK_ORIGIN_COLLECTION)) {
+            CouchbaseCollectionHelper.deleteAllDocuments(cluster, MONGOCK_BUCKET_NAME, CUSTOM_MONGOCK_ORIGIN_SCOPE, CUSTOM_MONGOCK_ORIGIN_COLLECTION);
+            CouchbaseCollectionHelper.waitUntilEmpty(cluster, MONGOCK_BUCKET_NAME, CUSTOM_MONGOCK_ORIGIN_SCOPE, CUSTOM_MONGOCK_ORIGIN_COLLECTION, Duration.ofSeconds(10));
+        }
     }
 
     @Test
@@ -300,15 +312,13 @@ public class CouchbaseImporterTest {
             "AND execute the pending flamingock changes")
     void GIVEN_allMongockChangeUnitsAlreadyExecutedAndCustomOriginProvided_WHEN_migratingToFlamingockCommunity_THEN_shouldImportEntireHistory() {
         // Setup Mongock entries
-        final String customMongockOriginScope = "mongockCustomScope";
-        final String customMongockOriginCollection = "mongockCustomOriginCollection";
-        final String customMongockOrigin = String.format("%s.%s", customMongockOriginScope, customMongockOriginCollection);
+        final String customMongockOrigin = String.format("%s.%s", CUSTOM_MONGOCK_ORIGIN_SCOPE, CUSTOM_MONGOCK_ORIGIN_COLLECTION);
 
-        CouchbaseCollectionHelper.createScopeIfNotExists(cluster, MONGOCK_BUCKET_NAME, customMongockOriginScope);
-        CouchbaseCollectionHelper.createCollectionIfNotExists(cluster, MONGOCK_BUCKET_NAME, customMongockOriginScope, customMongockOriginCollection);
-        CouchbaseCollectionHelper.createPrimaryIndexIfNotExists(cluster, MONGOCK_BUCKET_NAME, customMongockOriginScope, customMongockOriginCollection);
+        CouchbaseCollectionHelper.createScopeIfNotExists(cluster, MONGOCK_BUCKET_NAME, CUSTOM_MONGOCK_ORIGIN_SCOPE);
+        CouchbaseCollectionHelper.createCollectionIfNotExists(cluster, MONGOCK_BUCKET_NAME, CUSTOM_MONGOCK_ORIGIN_SCOPE, CUSTOM_MONGOCK_ORIGIN_COLLECTION);
+        CouchbaseCollectionHelper.createPrimaryIndexIfNotExists(cluster, MONGOCK_BUCKET_NAME, CUSTOM_MONGOCK_ORIGIN_SCOPE, CUSTOM_MONGOCK_ORIGIN_COLLECTION);
 
-        Collection originCollection = cluster.bucket(MONGOCK_BUCKET_NAME).scope(customMongockOriginScope).collection(customMongockOriginCollection);
+        Collection originCollection = cluster.bucket(MONGOCK_BUCKET_NAME).scope(CUSTOM_MONGOCK_ORIGIN_SCOPE).collection(CUSTOM_MONGOCK_ORIGIN_COLLECTION);
 
         originCollection.upsert("mongock-change-1", createAuditObject("mongock-change-1"));
 
@@ -352,6 +362,183 @@ public class CouchbaseImporterTest {
         assertEquals("APPLIED", auditLog.get(6).getString("state"));
     }
 
+    @Test
+    @DisplayName("GIVEN skip import flag with invalid value " +
+            "WHEN migrating to Flamingock Community" +
+            "THEN should throw exception")
+    void GIVEN_skipImportFlagWithInvalidValue_WHEN_migratingToFlamingockCommunity_THEN_shouldThrowException() {
+
+        final String SKIP_IMPORT_VALUE = "invalid_value";
+
+        CouchbaseTargetSystem targetSystem = new CouchbaseTargetSystem("couchbase-target-system", cluster, FLAMINGOCK_BUCKET_NAME);
+
+        Runner flamingock = FlamingockFactory.getCommunityBuilder()
+                .setAuditStore(CouchbaseAuditStore.from(targetSystem)
+                        .withScopeName(FLAMINGOCK_SCOPE_NAME)
+                        .withAuditRepositoryName(FLAMINGOCK_COLLECTION_NAME))
+                .addTargetSystem(targetSystem)
+                .setProperty(MONGOCK_IMPORT_SKIP_PROPERTY_KEY, SKIP_IMPORT_VALUE) // only allows empty / true / false
+                .build();
+
+        FlamingockException ex = assertThrows(FlamingockException.class, flamingock::run);
+        assertEquals("Invalid value for " + MONGOCK_IMPORT_SKIP_PROPERTY_KEY + ": " + SKIP_IMPORT_VALUE
+                + " (expected \"true\" or \"false\" or empty)", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("GIVEN all Mongock changeUnits already executed " +
+            "AND skip import flag enabled " +
+            "WHEN migrating to Flamingock Community" +
+            "THEN should not import any audit history entry " +
+            "AND execute the all mongock and flamingock changes")
+    void GIVEN_skipImportFlagEnabled_WHEN_migratingToFlamingockCommunity_THEN_shouldNotMigrateAnyAuditLog() {
+
+        Collection originCollection = cluster.bucket(MONGOCK_BUCKET_NAME).scope(MONGOCK_SCOPE_NAME).collection(MONGOCK_COLLECTION_NAME);
+
+        originCollection.upsert("mongock-change-1", createAuditObject("mongock-change-1"));
+        originCollection.upsert("mongock-change-2", createAuditObject("mongock-change-2"));
+
+        final String SKIP_IMPORT_VALUE = "true";
+
+        CouchbaseTargetSystem targetSystem = new CouchbaseTargetSystem("couchbase-target-system", cluster, FLAMINGOCK_BUCKET_NAME);
+
+        Runner flamingock = FlamingockFactory.getCommunityBuilder()
+                .setAuditStore(CouchbaseAuditStore.from(targetSystem)
+                        .withScopeName(FLAMINGOCK_SCOPE_NAME)
+                        .withAuditRepositoryName(FLAMINGOCK_COLLECTION_NAME))
+                .addTargetSystem(targetSystem)
+                .setProperty(MONGOCK_IMPORT_SKIP_PROPERTY_KEY, SKIP_IMPORT_VALUE) // only allows empty / true / false
+                .build();
+
+        flamingock.run();
+
+        List<JsonObject> auditLog = getAuditLog();
+
+        assertEquals(8, auditLog.size());
+
+        assertEquals("migration-mongock-to-flamingock-community", auditLog.get(0).getString("changeId"));
+        assertEquals("STARTED", auditLog.get(0).getString("state"));
+
+        assertEquals("migration-mongock-to-flamingock-community", auditLog.get(1).getString("changeId"));
+        assertEquals("APPLIED", auditLog.get(1).getString("state"));
+
+        assertEquals("mongock-change-1", auditLog.get(2).getString("changeId"));
+        assertEquals("STARTED", auditLog.get(2).getString("state"));
+
+        assertEquals("mongock-change-1", auditLog.get(3).getString("changeId"));
+        assertEquals("APPLIED", auditLog.get(3).getString("state"));
+
+        assertEquals("mongock-change-2", auditLog.get(4).getString("changeId"));
+        assertEquals("STARTED", auditLog.get(4).getString("state"));
+
+        assertEquals("mongock-change-2", auditLog.get(5).getString("changeId"));
+        assertEquals("APPLIED", auditLog.get(5).getString("state"));
+
+        assertEquals("flamingock-change", auditLog.get(6).getString("changeId"));
+        assertEquals("STARTED", auditLog.get(6).getString("state"));
+
+        assertEquals("flamingock-change", auditLog.get(7).getString("changeId"));
+        assertEquals("APPLIED", auditLog.get(7).getString("state"));
+    }
+
+    @Test
+    @DisplayName("GIVEN all Mongock changeUnits already executed " +
+            "AND skip import flag disabled (explicit) " +
+            "WHEN migrating to Flamingock Community " +
+            "THEN should import the entire history " +
+            "AND execute the pending flamingock changes")
+    void GIVEN_allMongockChangeUnitsAlreadyExecutedAndSkipImportFlagDisabledExplicit_WHEN_migratingToFlamingockCommunity_THEN_shouldImportEntireHistory() {
+        Collection originCollection = cluster.bucket(MONGOCK_BUCKET_NAME).scope(MONGOCK_SCOPE_NAME).collection(MONGOCK_COLLECTION_NAME);
+
+        originCollection.upsert("mongock-change-1", createAuditObject("mongock-change-1"));
+        originCollection.upsert("mongock-change-2", createAuditObject("mongock-change-2"));
+
+        CouchbaseTargetSystem targetSystem = new CouchbaseTargetSystem("couchbase-target-system", cluster, FLAMINGOCK_BUCKET_NAME);
+
+        final String SKIP_IMPORT_VALUE = "false";
+
+        Runner flamingock = FlamingockFactory.getCommunityBuilder()
+                .setAuditStore(CouchbaseAuditStore.from(targetSystem)
+                        .withScopeName(FLAMINGOCK_SCOPE_NAME)
+                        .withAuditRepositoryName(FLAMINGOCK_COLLECTION_NAME))
+                .addTargetSystem(targetSystem)
+                .setProperty(MONGOCK_IMPORT_SKIP_PROPERTY_KEY, SKIP_IMPORT_VALUE) // only allows empty / true / false
+                .build();
+
+        flamingock.run();
+
+        List<JsonObject> auditLog = getAuditLog();
+
+        assertEquals(6, auditLog.size());
+
+        assertEquals("mongock-change-1", auditLog.get(0).getString("changeId"));
+        assertEquals("APPLIED", auditLog.get(0).getString("state"));
+
+        assertEquals("mongock-change-2", auditLog.get(1).getString("changeId"));
+        assertEquals("APPLIED", auditLog.get(1).getString("state"));
+
+        assertEquals("migration-mongock-to-flamingock-community", auditLog.get(2).getString("changeId"));
+        assertEquals("STARTED", auditLog.get(2).getString("state"));
+
+        assertEquals("migration-mongock-to-flamingock-community", auditLog.get(3).getString("changeId"));
+        assertEquals("APPLIED", auditLog.get(3).getString("state"));
+
+        assertEquals("flamingock-change", auditLog.get(4).getString("changeId"));
+        assertEquals("STARTED", auditLog.get(4).getString("state"));
+
+        assertEquals("flamingock-change", auditLog.get(5).getString("changeId"));
+        assertEquals("APPLIED", auditLog.get(5).getString("state"));
+    }
+
+    @Test
+    @DisplayName("GIVEN all Mongock changeUnits already executed " +
+            "AND skip import flag disabled (implicit) " +
+            "WHEN migrating to Flamingock Community " +
+            "THEN should import the entire history " +
+            "AND execute the pending flamingock changes")
+    void GIVEN_allMongockChangeUnitsAlreadyExecutedAndSkipImportFlagDisabledImplicit_WHEN_migratingToFlamingockCommunity_THEN_shouldImportEntireHistory() {
+        Collection originCollection = cluster.bucket(MONGOCK_BUCKET_NAME).scope(MONGOCK_SCOPE_NAME).collection(MONGOCK_COLLECTION_NAME);
+
+        originCollection.upsert("mongock-change-1", createAuditObject("mongock-change-1"));
+        originCollection.upsert("mongock-change-2", createAuditObject("mongock-change-2"));
+
+        CouchbaseTargetSystem targetSystem = new CouchbaseTargetSystem("couchbase-target-system", cluster, FLAMINGOCK_BUCKET_NAME);
+
+        final String SKIP_IMPORT_VALUE = "";
+
+        Runner flamingock = FlamingockFactory.getCommunityBuilder()
+                .setAuditStore(CouchbaseAuditStore.from(targetSystem)
+                        .withScopeName(FLAMINGOCK_SCOPE_NAME)
+                        .withAuditRepositoryName(FLAMINGOCK_COLLECTION_NAME))
+                .addTargetSystem(targetSystem)
+                .setProperty(MONGOCK_IMPORT_SKIP_PROPERTY_KEY, SKIP_IMPORT_VALUE) // only allows empty / true / false
+                .build();
+
+        flamingock.run();
+
+        List<JsonObject> auditLog = getAuditLog();
+
+        assertEquals(6, auditLog.size());
+
+        assertEquals("mongock-change-1", auditLog.get(0).getString("changeId"));
+        assertEquals("APPLIED", auditLog.get(0).getString("state"));
+
+        assertEquals("mongock-change-2", auditLog.get(1).getString("changeId"));
+        assertEquals("APPLIED", auditLog.get(1).getString("state"));
+
+        assertEquals("migration-mongock-to-flamingock-community", auditLog.get(2).getString("changeId"));
+        assertEquals("STARTED", auditLog.get(2).getString("state"));
+
+        assertEquals("migration-mongock-to-flamingock-community", auditLog.get(3).getString("changeId"));
+        assertEquals("APPLIED", auditLog.get(3).getString("state"));
+
+        assertEquals("flamingock-change", auditLog.get(4).getString("changeId"));
+        assertEquals("STARTED", auditLog.get(4).getString("state"));
+
+        assertEquals("flamingock-change", auditLog.get(5).getString("changeId"));
+        assertEquals("APPLIED", auditLog.get(5).getString("state"));
+    }
+
 
     private List<JsonObject> getAuditLog() {
         return CouchbaseCollectionHelper.selectAllDocuments(cluster, FLAMINGOCK_BUCKET_NAME, FLAMINGOCK_SCOPE_NAME, FLAMINGOCK_COLLECTION_NAME)
@@ -379,5 +566,4 @@ public class CouchbaseImporterTest {
                 .put("_doctype", "mongockChangeEntry");
         return doc;
     }
-
 }

--- a/legacy/mongock-importer-dynamodb/src/test/java/io/flamingock/importer/mongock/dynamodb/DynamoDBImporterTest.java
+++ b/legacy/mongock-importer-dynamodb/src/test/java/io/flamingock/importer/mongock/dynamodb/DynamoDBImporterTest.java
@@ -49,6 +49,7 @@ import static io.flamingock.core.kit.audit.AuditEntryExpectation.STARTED;
 import static io.flamingock.internal.common.core.metadata.Constants.DEFAULT_MONGOCK_ORIGIN;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_ORIGIN_PROPERTY_KEY;
+import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_SKIP_PROPERTY_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -310,6 +311,188 @@ public class DynamoDBImporterTest {
         Runner flamingock = testKit.createBuilder()
                 .addTargetSystem(dynamodbTargetSystem)
                 .setProperty(MONGOCK_IMPORT_ORIGIN_PROPERTY_KEY, customMongockOrigin)
+                .build();
+
+        flamingock.run();
+
+        // Verify audit sequence: 9 total entries as shown in actual execution
+        // Legacy imports only show APPLIED (imported from Mongock), new changes show STARTED+APPLIED
+        auditHelper.verifyAuditSequenceStrict(
+                // Legacy imports from Mongock (APPLIED only - no STARTED for imported changes)
+                APPLIED("system-change-00001_before"),
+                APPLIED("system-change-00001"),
+                APPLIED("mongock-change-1_before"),
+                APPLIED("mongock-change-1"),
+                APPLIED("mongock-change-2"),
+
+                // System stage - actual system importer change
+                STARTED("migration-mongock-to-flamingock-community"),
+                APPLIED("migration-mongock-to-flamingock-community"),
+
+                // Application stage - new changes created by templates
+                STARTED("create-users-table"),
+                APPLIED("create-users-table")
+        );
+
+
+
+        // Validate actual table creation
+        assertTrue(client.listTables().tableNames().contains("users"), "Users table should exist");
+
+        // Verify table structure
+        DescribeTableResponse tableDescription = client.describeTable(
+                DescribeTableRequest.builder().tableName("users").build()
+        );
+        assertEquals("email", tableDescription.table().keySchema().get(0).attributeName());
+        assertEquals(KeyType.HASH, tableDescription.table().keySchema().get(0).keyType());
+    }
+
+    @Test
+    @DisplayName("GIVEN skip import flag with invalid value " +
+            "WHEN migrating to Flamingock Community" +
+            "THEN should throw exception")
+    void GIVEN_skipImportFlagWithInvalidValue_WHEN_migratingToFlamingockCommunity_THEN_shouldThrowException() {
+        // Setup Mongock entries
+
+        DynamoDBTargetSystem dynamodbTargetSystem = new DynamoDBTargetSystem("dynamodb-target-system", client);
+
+        final String SKIP_IMPORT_VALUE = "invalid_value";
+
+        Runner flamingock = testKit.createBuilder()
+                .addTargetSystem(dynamodbTargetSystem)
+                .setProperty(MONGOCK_IMPORT_SKIP_PROPERTY_KEY, SKIP_IMPORT_VALUE) // only allows empty / true / false
+                .build();
+
+        FlamingockException ex = assertThrows(FlamingockException.class, flamingock::run);
+        assertEquals("Invalid value for " + MONGOCK_IMPORT_SKIP_PROPERTY_KEY + ": " + SKIP_IMPORT_VALUE
+                + " (expected \"true\" or \"false\" or empty)", ex.getMessage());
+
+    }
+
+    @Test
+    @DisplayName("GIVEN all Mongock changeUnits already executed " +
+            "AND skip import flag enabled " +
+            "WHEN migrating to Flamingock Community" +
+            "THEN should not import any audit history entry " +
+            "AND execute the all mongock and flamingock changes")
+    void GIVEN_skipImportFlagEnabled_WHEN_migratingToFlamingockCommunity_THEN_shouldNotMigrateAnyAuditLog() {
+
+        // Setup Mongock entries
+        mongockTestHelper.setupBasicScenario();
+
+        DynamoDBTargetSystem dynamodbTargetSystem = new DynamoDBTargetSystem("dynamodb-target-system", client);
+
+        final String SKIP_IMPORT_VALUE = "true";
+
+        Runner flamingock = testKit.createBuilder()
+                .addTargetSystem(dynamodbTargetSystem)
+                .setProperty(MONGOCK_IMPORT_SKIP_PROPERTY_KEY, SKIP_IMPORT_VALUE) // only allows empty / true / false
+                .build();
+
+        flamingock.run();
+
+        // Verify audit sequence: 8 total entries as shown in actual execution
+        auditHelper.verifyAuditSequenceStrict(
+                // System stage - actual system importer change
+                STARTED("migration-mongock-to-flamingock-community"),
+                APPLIED("migration-mongock-to-flamingock-community"),
+
+                // Legacy changes
+                STARTED("mongock-change-1"),
+                APPLIED("mongock-change-1"),
+                STARTED("mongock-change-2"),
+                APPLIED("mongock-change-2"),
+
+                // Application stage - new changes created by templates
+                STARTED("create-users-table"),
+                APPLIED("create-users-table")
+        );
+
+
+
+        // Validate actual table creation
+        assertTrue(client.listTables().tableNames().contains("users"), "Users table should exist");
+
+        // Verify table structure
+        DescribeTableResponse tableDescription = client.describeTable(
+                DescribeTableRequest.builder().tableName("users").build()
+        );
+        assertEquals("email", tableDescription.table().keySchema().get(0).attributeName());
+        assertEquals(KeyType.HASH, tableDescription.table().keySchema().get(0).keyType());
+    }
+
+    @Test
+    @DisplayName("GIVEN all Mongock changeUnits already executed " +
+            "AND skip import flag disabled (explicit) " +
+            "WHEN migrating to Flamingock Community " +
+            "THEN should import the entire history " +
+            "AND execute the pending flamingock changes")
+    void GIVEN_allMongockChangeUnitsAlreadyExecutedAndSkipImportFlagDisabledExplicit_WHEN_migratingToFlamingockCommunity_THEN_shouldImportEntireHistory() {
+
+        // Setup Mongock entries
+        mongockTestHelper.setupBasicScenario();
+
+        DynamoDBTargetSystem dynamodbTargetSystem = new DynamoDBTargetSystem("dynamodb-target-system", client);
+
+        final String SKIP_IMPORT_VALUE = "false";
+
+        Runner flamingock = testKit.createBuilder()
+                .addTargetSystem(dynamodbTargetSystem)
+                .setProperty(MONGOCK_IMPORT_SKIP_PROPERTY_KEY, SKIP_IMPORT_VALUE) // only allows empty / true / false
+                .build();
+
+        flamingock.run();
+
+        // Verify audit sequence: 9 total entries as shown in actual execution
+        // Legacy imports only show APPLIED (imported from Mongock), new changes show STARTED+APPLIED
+        auditHelper.verifyAuditSequenceStrict(
+                // Legacy imports from Mongock (APPLIED only - no STARTED for imported changes)
+                APPLIED("system-change-00001_before"),
+                APPLIED("system-change-00001"),
+                APPLIED("mongock-change-1_before"),
+                APPLIED("mongock-change-1"),
+                APPLIED("mongock-change-2"),
+
+                // System stage - actual system importer change
+                STARTED("migration-mongock-to-flamingock-community"),
+                APPLIED("migration-mongock-to-flamingock-community"),
+
+                // Application stage - new changes created by templates
+                STARTED("create-users-table"),
+                APPLIED("create-users-table")
+        );
+
+
+
+        // Validate actual table creation
+        assertTrue(client.listTables().tableNames().contains("users"), "Users table should exist");
+
+        // Verify table structure
+        DescribeTableResponse tableDescription = client.describeTable(
+                DescribeTableRequest.builder().tableName("users").build()
+        );
+        assertEquals("email", tableDescription.table().keySchema().get(0).attributeName());
+        assertEquals(KeyType.HASH, tableDescription.table().keySchema().get(0).keyType());
+    }
+
+    @Test
+    @DisplayName("GIVEN all Mongock changeUnits already executed " +
+            "AND skip import flag disabled (implicit) " +
+            "WHEN migrating to Flamingock Community " +
+            "THEN should import the entire history " +
+            "AND execute the pending flamingock changes")
+    void GIVEN_allMongockChangeUnitsAlreadyExecutedAndSkipImportFlagDisabledImplicit_WHEN_migratingToFlamingockCommunity_THEN_shouldImportEntireHistory() {
+
+        // Setup Mongock entries
+        mongockTestHelper.setupBasicScenario();
+
+        DynamoDBTargetSystem dynamodbTargetSystem = new DynamoDBTargetSystem("dynamodb-target-system", client);
+
+        final String SKIP_IMPORT_VALUE = "";
+
+        Runner flamingock = testKit.createBuilder()
+                .addTargetSystem(dynamodbTargetSystem)
+                .setProperty(MONGOCK_IMPORT_SKIP_PROPERTY_KEY, SKIP_IMPORT_VALUE) // only allows empty / true / false
                 .build();
 
         flamingock.run();

--- a/legacy/mongock-importer-mongodb/src/test/java/io/flamingock/importer/mongock/mongodb/MongoDBImporterTest.java
+++ b/legacy/mongock-importer-mongodb/src/test/java/io/flamingock/importer/mongock/mongodb/MongoDBImporterTest.java
@@ -49,6 +49,7 @@ import static io.flamingock.core.kit.audit.AuditEntryExpectation.STARTED;
 import static io.flamingock.internal.common.core.metadata.Constants.DEFAULT_MONGOCK_ORIGIN;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_ORIGIN_PROPERTY_KEY;
+import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_SKIP_PROPERTY_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -351,6 +352,203 @@ public class MongoDBImporterTest {
         );
 
 
+
+
+        // Validate actual change
+        List<Document> users = database.getCollection("users")
+                .find()
+                .into(new ArrayList<>());
+
+        assertEquals(2, users.size());
+        Assertions.assertEquals("Admin", users.get(0).getString("name"));
+        Assertions.assertEquals("admin@company.com", users.get(0).getString("email"));
+        Assertions.assertEquals("superuser", users.get(0).getList("roles", String.class).get(0));
+
+        Assertions.assertEquals("Backup", users.get(1).getString("name"));
+        Assertions.assertEquals("backup@company.com", users.get(1).getString("email"));
+        Assertions.assertEquals("readonly", users.get(1).getList("roles", String.class).get(0));
+    }
+
+    @Test
+    @DisplayName("GIVEN skip import flag with invalid value " +
+            "WHEN migrating to Flamingock Community" +
+            "THEN should throw exception")
+    void GIVEN_skipImportFlagWithInvalidValue_WHEN_migratingToFlamingockCommunity_THEN_shouldThrowException() {
+        // Setup Mongock entries
+
+        MongoDBSyncTargetSystem mongodbTargetSystem = new MongoDBSyncTargetSystem("mongodb-target-system", mongoClient, DATABASE_NAME);
+
+        final String SKIP_IMPORT_VALUE = "invalid_value";
+
+        Runner flamingock = testKit.createBuilder()
+                .addTargetSystem(mongodbTargetSystem)
+                .setProperty(MONGOCK_IMPORT_SKIP_PROPERTY_KEY, SKIP_IMPORT_VALUE) // only allows empty / true / false
+                .build();
+
+        FlamingockException ex = assertThrows(FlamingockException.class, flamingock::run);
+        assertEquals("Invalid value for " + MONGOCK_IMPORT_SKIP_PROPERTY_KEY + ": " + SKIP_IMPORT_VALUE
+                + " (expected \"true\" or \"false\" or empty)", ex.getMessage());
+    }
+
+
+    @Test
+    @DisplayName("GIVEN all Mongock changeUnits already executed " +
+            "AND skip import flag enabled " +
+            "WHEN migrating to Flamingock Community" +
+            "THEN should not import any audit history entry " +
+            "AND execute the all mongock and flamingock changes")
+    void GIVEN_skipImportFlagEnabled_WHEN_migratingToFlamingockCommunity_THEN_shouldNotMigrateAnyAuditLog() {
+
+        // Setup Mongock entries
+        mongockTestHelper.setupBasicScenario();
+
+        MongoDBSyncTargetSystem mongodbTargetSystem = new MongoDBSyncTargetSystem("mongodb-target-system", mongoClient, DATABASE_NAME);
+
+        final String SKIP_IMPORT_VALUE = "true";
+
+        Runner flamingock = testKit.createBuilder()
+                .addTargetSystem(mongodbTargetSystem)
+                .setProperty(MONGOCK_IMPORT_SKIP_PROPERTY_KEY, SKIP_IMPORT_VALUE) // only allows empty / true / false
+                .build();
+
+        flamingock.run();
+
+        // Verify audit sequence: 10 total entries as shown in actual execution
+        auditHelper.verifyAuditSequenceStrict(
+                // System stage - actual system importer change
+                STARTED("migration-mongock-to-flamingock-community"),
+                APPLIED("migration-mongock-to-flamingock-community"),
+
+                // Legacy changes
+                STARTED("mongock-change-1"),
+                APPLIED("mongock-change-1"),
+                STARTED("mongock-change-2"),
+                APPLIED("mongock-change-2"),
+
+                // Application stage - new changes created by templates
+                STARTED("create-users-collection-with-index"),
+                APPLIED("create-users-collection-with-index"),
+                STARTED("seed-users"),
+                APPLIED("seed-users")
+        );
+
+
+        // Validate actual change
+        List<Document> users = database.getCollection("users")
+                .find()
+                .into(new ArrayList<>());
+
+        assertEquals(2, users.size());
+        Assertions.assertEquals("Admin", users.get(0).getString("name"));
+        Assertions.assertEquals("admin@company.com", users.get(0).getString("email"));
+        Assertions.assertEquals("superuser", users.get(0).getList("roles", String.class).get(0));
+
+        Assertions.assertEquals("Backup", users.get(1).getString("name"));
+        Assertions.assertEquals("backup@company.com", users.get(1).getString("email"));
+        Assertions.assertEquals("readonly", users.get(1).getList("roles", String.class).get(0));
+    }
+
+    @Test
+    @DisplayName("GIVEN all Mongock changeUnits already executed " +
+            "AND skip import flag disabled (explicit) " +
+            "WHEN migrating to Flamingock Community " +
+            "THEN should import the entire history " +
+            "AND execute the pending flamingock changes")
+    void GIVEN_allMongockChangeUnitsAlreadyExecutedAndSkipImportFlagDisabledExplicit_WHEN_migratingToFlamingockCommunity_THEN_shouldImportEntireHistory() {
+
+        // Setup Mongock entries
+        mongockTestHelper.setupBasicScenario();
+
+        MongoDBSyncTargetSystem mongodbTargetSystem = new MongoDBSyncTargetSystem("mongodb-target-system", mongoClient, DATABASE_NAME);
+
+        final String SKIP_IMPORT_VALUE = "false";
+
+        Runner flamingock = testKit.createBuilder()
+                .addTargetSystem(mongodbTargetSystem)
+                .setProperty(MONGOCK_IMPORT_SKIP_PROPERTY_KEY, SKIP_IMPORT_VALUE) // only allows empty / true / false
+                .build();
+
+        flamingock.run();
+
+        // Verify audit sequence: 11 total entries as shown in actual execution
+        // Legacy imports only show APPLIED (imported from Mongock), new changes show STARTED+APPLIED
+        auditHelper.verifyAuditSequenceStrict(
+                // Legacy imports from Mongock (APPLIED only - no STARTED for imported changes)
+                APPLIED("system-change-00001_before"),
+                APPLIED("system-change-00001"),
+                APPLIED("mongock-change-1_before"),
+                APPLIED("mongock-change-1"),
+                APPLIED("mongock-change-2"),
+
+                // System stage - actual system importer change
+                STARTED("migration-mongock-to-flamingock-community"),
+                APPLIED("migration-mongock-to-flamingock-community"),
+
+                // Application stage - new changes created by templates
+                STARTED("create-users-collection-with-index"),
+                APPLIED("create-users-collection-with-index"),
+                STARTED("seed-users"),
+                APPLIED("seed-users")
+        );
+
+
+        // Validate actual change
+        List<Document> users = database.getCollection("users")
+                .find()
+                .into(new ArrayList<>());
+
+        assertEquals(2, users.size());
+        Assertions.assertEquals("Admin", users.get(0).getString("name"));
+        Assertions.assertEquals("admin@company.com", users.get(0).getString("email"));
+        Assertions.assertEquals("superuser", users.get(0).getList("roles", String.class).get(0));
+
+        Assertions.assertEquals("Backup", users.get(1).getString("name"));
+        Assertions.assertEquals("backup@company.com", users.get(1).getString("email"));
+        Assertions.assertEquals("readonly", users.get(1).getList("roles", String.class).get(0));
+    }
+
+    @Test
+    @DisplayName("GIVEN all Mongock changeUnits already executed " +
+            "AND skip import flag disabled (implicit) " +
+            "WHEN migrating to Flamingock Community " +
+            "THEN should import the entire history " +
+            "AND execute the pending flamingock changes")
+    void GIVEN_allMongockChangeUnitsAlreadyExecutedAndSkipImportFlagDisabledImplicit_WHEN_migratingToFlamingockCommunity_THEN_shouldImportEntireHistory() {
+
+        // Setup Mongock entries
+        mongockTestHelper.setupBasicScenario();
+
+        MongoDBSyncTargetSystem mongodbTargetSystem = new MongoDBSyncTargetSystem("mongodb-target-system", mongoClient, DATABASE_NAME);
+
+        final String SKIP_IMPORT_VALUE = "";
+
+        Runner flamingock = testKit.createBuilder()
+                .addTargetSystem(mongodbTargetSystem)
+                .setProperty(MONGOCK_IMPORT_SKIP_PROPERTY_KEY, SKIP_IMPORT_VALUE) // only allows empty / true / false
+                .build();
+
+        flamingock.run();
+
+        // Verify audit sequence: 11 total entries as shown in actual execution
+        // Legacy imports only show APPLIED (imported from Mongock), new changes show STARTED+APPLIED
+        auditHelper.verifyAuditSequenceStrict(
+                // Legacy imports from Mongock (APPLIED only - no STARTED for imported changes)
+                APPLIED("system-change-00001_before"),
+                APPLIED("system-change-00001"),
+                APPLIED("mongock-change-1_before"),
+                APPLIED("mongock-change-1"),
+                APPLIED("mongock-change-2"),
+
+                // System stage - actual system importer change
+                STARTED("migration-mongock-to-flamingock-community"),
+                APPLIED("migration-mongock-to-flamingock-community"),
+
+                // Application stage - new changes created by templates
+                STARTED("create-users-collection-with-index"),
+                APPLIED("create-users-collection-with-index"),
+                STARTED("seed-users"),
+                APPLIED("seed-users")
+        );
 
 
         // Validate actual change

--- a/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/annotations/MongockSupport.java
+++ b/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/annotations/MongockSupport.java
@@ -82,6 +82,20 @@ public @interface MongockSupport {
     String targetSystem();
 
     /**
+     * Determines whether Mongock import should be skipped.
+     * <p>
+     * Expected literal values are {@code "true"} or {@code "false"}.
+     * </p>
+     *
+     * <p>
+     * If empty (default), it will be treated as {@code "false"}.
+     * </p>
+     *
+     * @return {@code "true"} to skip import, {@code "false"} to process it; empty treated as {@code "false"}
+     */
+    String skipImport() default "";
+
+    /**
      * Defines the origin collection/table name where Mongock audit entries are stored.
      * <p>
      * This value is optional. When empty (default), Flamingock will use Mongock's

--- a/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/processor/MongockAnnotationProcessorPlugin.java
+++ b/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/processor/MongockAnnotationProcessorPlugin.java
@@ -50,6 +50,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY;
+import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_SKIP_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_ORIGIN_PROPERTY_KEY;
 
 @SuppressWarnings("deprecation")
@@ -84,6 +85,7 @@ public class MongockAnnotationProcessorPlugin implements AnnotationProcessorPlug
                 .flatMap(List::stream)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
+
         changes.add(getImporterChange(mongockTargetSystemId));
 
         return changes;
@@ -142,16 +144,23 @@ public class MongockAnnotationProcessorPlugin implements AnnotationProcessorPlug
             throw new IllegalArgumentException("properties");
         }
 
+        // Skip Import
+        ConfigValueParser.ConfigValue skipImportValue =
+                ConfigValueParser.parse("skipImport", mongockSupport.skipImport(), ConfigValueParser.BOOLEAN_VALUE_VALIDATOR);
+        if (!skipImportValue.isEmpty()) {
+            properties.put(MONGOCK_IMPORT_SKIP_PROPERTY_KEY, skipImportValue.getRaw());
+        }
+
         // Empty Origin Allowed
         ConfigValueParser.ConfigValue emptyOriginAllowedValue =
-                ConfigValueParser.parse(MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY, mongockSupport.emptyOriginAllowed(), ConfigValueParser.BOOLEAN_VALUE_VALIDATOR);
+                ConfigValueParser.parse("emptyOriginAllowed", mongockSupport.emptyOriginAllowed(), ConfigValueParser.BOOLEAN_VALUE_VALIDATOR);
         if (!emptyOriginAllowedValue.isEmpty()) {
             properties.put(MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY, emptyOriginAllowedValue.getRaw());
         }
 
         // Origin
         ConfigValueParser.ConfigValue originValue =
-                ConfigValueParser.parse(MONGOCK_IMPORT_ORIGIN_PROPERTY_KEY, mongockSupport.origin());
+                ConfigValueParser.parse("origin", mongockSupport.origin());
         if (!originValue.isEmpty()) {
             properties.put(MONGOCK_IMPORT_ORIGIN_PROPERTY_KEY, originValue.getRaw());
         }

--- a/utils/couchbase-util/src/main/java/io/flamingock/internal/common/couchbase/CouchbaseCollectionHelper.java
+++ b/utils/couchbase-util/src/main/java/io/flamingock/internal/common/couchbase/CouchbaseCollectionHelper.java
@@ -37,7 +37,7 @@ import static io.flamingock.internal.common.couchbase.CouchbaseUtils.isDefaultCo
 public final class CouchbaseCollectionHelper {
 
     private final static String KEYSPACE_TEMPLATE = "`%s`.`%s`.`%s`";
-    private final static String SELECT_COUNT_QUERY_TEMPLATE = "SELECT COUNT(*) FROM `%s`.`%s`.`%s`";
+    private final static String SELECT_COUNT_QUERY_TEMPLATE = "SELECT COUNT(*) as cnt FROM `%s`.`%s`.`%s`";
     private final static String SELECT_ALL_QUERY_TEMPLATE = "SELECT %s.* FROM `%s`.`%s`.`%s`";
     private final static String DELETE_ALL_QUERY_TEMPLATE = "DELETE FROM `%s`.`%s`.`%s`";
     private final static String CREATE_PRIMARY_INDEX_TEMPLATE = "CREATE PRIMARY INDEX IF NOT EXISTS ON `%s`.`%s`.`%s`";
@@ -159,7 +159,8 @@ public final class CouchbaseCollectionHelper {
     }
 
     public static void deleteAllDocuments(Cluster cluster, String bucketName, String scopeName, String collectionName) {
-        cluster.query(String.format(DELETE_ALL_QUERY_TEMPLATE, bucketName, scopeName, collectionName));
+        cluster.query(String.format(DELETE_ALL_QUERY_TEMPLATE, bucketName, scopeName, collectionName),
+                QueryOptions.queryOptions().scanConsistency(QueryScanConsistency.REQUEST_PLUS));
     }
 
     public static void createPrimaryIndexIfNotExists(Cluster cluster, String bucketName, String scopeName, String collectionName) {
@@ -172,5 +173,45 @@ public final class CouchbaseCollectionHelper {
 
     public static void dropIndexIfExists(Cluster cluster, String bucketName, String scopeName, String collectionName, String indexName) {
         cluster.query(String.format(DROP_INDEX_TEMPLATE, indexName, bucketName, scopeName, collectionName));
+    }
+
+    public static void waitUntilEmpty(
+            Cluster cluster,
+            String bucketName,
+            String scopeName,
+            String collectionName,
+            Duration timeout
+    ) {
+        long deadline = System.nanoTime() + timeout.toNanos();
+
+        while (System.nanoTime() < deadline) {
+            String countQuery = String.format(SELECT_COUNT_QUERY_TEMPLATE, bucketName, scopeName, collectionName);
+
+            List<JsonObject> rows = cluster.query(countQuery,
+                    QueryOptions.queryOptions().scanConsistency(QueryScanConsistency.REQUEST_PLUS)).rowsAsObject();
+            long count = rows.isEmpty() ? 0L : rows.get(0).getLong("cnt");
+
+            if (count == 0L) {
+                return;
+            }
+
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(
+                        "Interrupted while waiting for collection cleanup",
+                        e
+                );
+            }
+        }
+
+        throw new IllegalStateException(String.format(
+                "Timeout waiting for collection %s.%s.%s to be empty after %s",
+                bucketName,
+                scopeName,
+                collectionName,
+                timeout
+        ));
     }
 }


### PR DESCRIPTION
- **chore: bump version to 1.2.0-beta.1**
- **chore: added flamingock-template-api to release actions**
- **feat: added skipImport flag to MongockSupport annotation (#855)**
- **refactor(graalvm): register template field hierarchy classes for reflection (#866)**
- **chore: bump version to 1.0.0-beta.2**
- **fix(core): return STANDARD_TEMPLATE for template-based audit entries**
