### PR TITLE
feat: added flag to ignore unknown changes when migrating from Mongock

### DIFF
--- a/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/metadata/Constants.java
+++ b/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/metadata/Constants.java
@@ -28,6 +28,7 @@ public final class Constants {
     public static final String MONGOCK_IMPORT_SKIP_PROPERTY_KEY = "internal.mongock.import.skip";
     public static final String MONGOCK_IMPORT_ORIGIN_PROPERTY_KEY = "internal.mongock.import.origin";
     public static final String MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY = "internal.mongock.import.emptyOriginAllowed";
+    public static final String MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY = "internal.mongock.import.ignoreUnknownAuditEntries";
 
     private Constants() {}
 

--- a/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/metadata/Constants.java
+++ b/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/metadata/Constants.java
@@ -28,7 +28,7 @@ public final class Constants {
     public static final String MONGOCK_IMPORT_SKIP_PROPERTY_KEY = "internal.mongock.import.skip";
     public static final String MONGOCK_IMPORT_ORIGIN_PROPERTY_KEY = "internal.mongock.import.origin";
     public static final String MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY = "internal.mongock.import.emptyOriginAllowed";
-    public static final String MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY = "internal.mongock.import.ignoreUnknownAuditEntries";
+    public static final String MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY = "internal.mongock.import.ignoreUnknownEntries";
 
     private Constants() {}
 

--- a/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/pipeline/PipelineHelper.java
+++ b/core/flamingock-core-commons/src/main/java/io/flamingock/internal/common/core/pipeline/PipelineHelper.java
@@ -16,14 +16,13 @@
 package io.flamingock.internal.common.core.pipeline;
 
 import io.flamingock.internal.common.core.audit.AuditEntry;
-import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
 
 public class PipelineHelper {
 
     public static final String SYSTEM_STAGE_ID = "flamingock-system-stage";
     public static final String LEGACY_STAGE_ID = "flamingock-legacy-stage";
-
-    private static final String errorTemplate = "importing change with id[%s] from database. It must be imported  to a flamingock stage";
 
     private final PipelineDescriptor pipelineDescriptor;
 
@@ -31,16 +30,13 @@ public class PipelineHelper {
         this.pipelineDescriptor = pipelineDescriptor;
     }
 
-    public String getStageId(AuditEntry auditEntryFromOrigin) {
+    public Optional<String> findStageId(AuditEntry auditEntryFromOrigin) {
         if (Boolean.TRUE.equals(auditEntryFromOrigin.getSystemChange())) {
-            return LEGACY_STAGE_ID;
-        } else {
-            String changeIdInPipeline = getBaseChangeId(auditEntryFromOrigin);
-            return pipelineDescriptor.getStageByChange(changeIdInPipeline).orElseThrow(() -> generateChangeIdException(changeIdInPipeline));
+            return Optional.of(LEGACY_STAGE_ID);
         }
+        String changeIdInPipeline = getBaseChangeId(auditEntryFromOrigin);
+        return pipelineDescriptor.getStageByChange(changeIdInPipeline);
     }
-
-
 
     public String getBaseChangeId(AuditEntry auditEntry) {
         String originalChangeId = auditEntry.getChangeId();
@@ -50,10 +46,5 @@ public class PipelineHelper {
 
     public String getStorableChangeId(AuditEntry auditEntry) {
         return auditEntry.getChangeId();
-    }
-
-    @NotNull
-    public IllegalArgumentException generateChangeIdException(String changeIdInPipeline) {
-        return new IllegalArgumentException(String.format(errorTemplate, changeIdInPipeline));
     }
 }

--- a/core/flamingock-core-commons/src/test/java/io/flamingock/internal/common/core/pipeline/PipelineHelperTest.java
+++ b/core/flamingock-core-commons/src/test/java/io/flamingock/internal/common/core/pipeline/PipelineHelperTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Flamingock (https://www.flamingock.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.flamingock.internal.common.core.pipeline;
+
+import io.flamingock.api.RecoveryStrategy;
+import io.flamingock.internal.common.core.audit.AuditEntry;
+import io.flamingock.internal.common.core.change.ChangeDescriptor;
+import io.flamingock.internal.common.core.context.ContextInjectable;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static io.flamingock.internal.common.core.pipeline.PipelineHelper.LEGACY_STAGE_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PipelineHelperTest {
+
+    private final PipelineHelper pipelineHelper = new PipelineHelper(new PipelineDescriptor() {
+        @Override
+        public Optional<? extends ChangeDescriptor> getLoadedChange(String changeId) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> getStageByChange(String changeId) {
+            return "known-change".equals(changeId) ? Optional.of("user-stage") : Optional.empty();
+        }
+
+        @Override
+        public void contributeToContext(ContextInjectable contextInjectable) {
+            // no-op for unit test
+        }
+    });
+
+    @Test
+    void shouldReturnLegacyStageForSystemChange() {
+        Optional<String> stageId = pipelineHelper.findStageId(buildAuditEntry("system-change-1", true));
+
+        assertEquals(Optional.of(LEGACY_STAGE_ID), stageId);
+    }
+
+    @Test
+    void shouldReturnMatchingStageForKnownChange() {
+        Optional<String> stageId = pipelineHelper.findStageId(buildAuditEntry("known-change", false));
+
+        assertEquals(Optional.of("user-stage"), stageId);
+    }
+
+    @Test
+    void shouldReturnEmptyForUnknownChange() {
+        Optional<String> stageId = pipelineHelper.findStageId(buildAuditEntry("unknown-change", false));
+
+        assertFalse(stageId.isPresent());
+    }
+
+    private static AuditEntry buildAuditEntry(String changeId, boolean systemChange) {
+        return new AuditEntry(
+                "exec-1",
+                null,
+                changeId,
+                "author",
+                LocalDateTime.now(),
+                AuditEntry.Status.APPLIED,
+                AuditEntry.ChangeType.MONGOCK_EXECUTION,
+                "io.example.Change",
+                "apply",
+                null,
+                10L,
+                "host",
+                null,
+                systemChange,
+                null,
+                null,
+                null,
+                null,
+                RecoveryStrategy.MANUAL_INTERVENTION,
+                null
+        );
+    }
+}

--- a/legacy/mongock-importer-couchbase/src/test/java/io/flamingock/importer/mongock/couchbase/CouchbaseImporterTest.java
+++ b/legacy/mongock-importer-couchbase/src/test/java/io/flamingock/importer/mongock/couchbase/CouchbaseImporterTest.java
@@ -52,7 +52,7 @@ import java.util.stream.Collectors;
 import static io.flamingock.core.kit.audit.AuditEntryExpectation.APPLIED;
 import static io.flamingock.core.kit.audit.AuditEntryExpectation.STARTED;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY;
-import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY;
+import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_ORIGIN_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_SKIP_PROPERTY_KEY;
 import static io.flamingock.internal.util.constants.AuditEntryFieldConstants.KEY_CREATED_AT;
@@ -359,7 +359,7 @@ public class CouchbaseImporterTest {
         Runner flamingock = testKit.createBuilder()
                 .setAuditStore(auditStore)
                 .addTargetSystem(targetSystem)
-                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY, Boolean.FALSE.toString())
+                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY, Boolean.FALSE.toString())
                 .build();
 
         StagedExecuteOperationException ex = assertThrows(StagedExecuteOperationException.class, flamingock::run);
@@ -383,7 +383,7 @@ public class CouchbaseImporterTest {
         Runner flamingock = testKit.createBuilder()
                 .setAuditStore(auditStore)
                 .addTargetSystem(targetSystem)
-                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY, Boolean.TRUE.toString())
+                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY, Boolean.TRUE.toString())
                 .build();
 
         flamingock.run();
@@ -414,11 +414,11 @@ public class CouchbaseImporterTest {
         Runner flamingock = testKit.createBuilder()
                 .setAuditStore(auditStore)
                 .addTargetSystem(targetSystem)
-                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY, flagValue)
+                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY, flagValue)
                 .build();
 
         StagedExecuteOperationException ex = assertThrows(StagedExecuteOperationException.class, flamingock::run);
-        assertEquals("Invalid value for " + MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY + ": " + flagValue
+        assertEquals("Invalid value for " + MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY + ": " + flagValue
                 + " (expected \"true\" or \"false\" or empty)", firstFailedStageErrorMessage(ex));
     }
 

--- a/legacy/mongock-importer-couchbase/src/test/java/io/flamingock/importer/mongock/couchbase/CouchbaseImporterTest.java
+++ b/legacy/mongock-importer-couchbase/src/test/java/io/flamingock/importer/mongock/couchbase/CouchbaseImporterTest.java
@@ -30,7 +30,6 @@ import io.flamingock.internal.common.core.audit.AuditEntry;
 import io.flamingock.store.couchbase.CouchbaseAuditStore;
 import io.flamingock.internal.common.core.response.data.ErrorInfo;
 import io.flamingock.internal.common.couchbase.CouchbaseCollectionHelper;
-import io.flamingock.internal.core.builder.FlamingockFactory;
 import io.flamingock.internal.core.builder.runner.Runner;
 import io.flamingock.internal.core.operation.StagedExecuteOperationException;
 import io.flamingock.internal.util.constants.CommunityPersistenceConstants;
@@ -53,6 +52,7 @@ import java.util.stream.Collectors;
 import static io.flamingock.core.kit.audit.AuditEntryExpectation.APPLIED;
 import static io.flamingock.core.kit.audit.AuditEntryExpectation.STARTED;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY;
+import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_ORIGIN_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_SKIP_PROPERTY_KEY;
 import static io.flamingock.internal.util.constants.AuditEntryFieldConstants.KEY_CREATED_AT;
@@ -321,6 +321,108 @@ public class CouchbaseImporterTest {
     }
 
     @Test
+    @DisplayName("GIVEN Mongock audit history contains unknown entries " +
+            "AND relaxed import flag is not provided " +
+            "WHEN migrating to Flamingock Community " +
+            "THEN should fail with the current strict validation")
+    void GIVEN_unknownAuditEntriesAndImplicitStrictMode_WHEN_migratingToFlamingockCommunity_THEN_shouldFail() {
+        Collection originCollection = cluster.bucket(MONGOCK_BUCKET_NAME).scope(MONGOCK_SCOPE_NAME).collection(MONGOCK_COLLECTION_NAME);
+
+        originCollection.upsert("mongock-change-1", createAuditObject("mongock-change-1"));
+        originCollection.upsert("foreign-change-1", createAuditObject("foreign-change-1", false, "io.example.foreign.ForeignChangeUnit", "apply"));
+
+        CouchbaseTargetSystem targetSystem = new CouchbaseTargetSystem("couchbase-target-system", cluster, FLAMINGOCK_BUCKET_NAME);
+
+        Runner flamingock = testKit.createBuilder()
+                .setAuditStore(auditStore)
+                .addTargetSystem(targetSystem)
+                .build();
+
+        StagedExecuteOperationException ex = assertThrows(StagedExecuteOperationException.class, flamingock::run);
+        assertEquals("Error importing audit entry with changeId[foreign-change-1]: no matching change was found in the current Flamingock pipeline.",
+                firstFailedStageErrorMessage(ex));
+    }
+
+    @Test
+    @DisplayName("GIVEN Mongock audit history contains unknown entries " +
+            "AND relaxed import flag is explicitly disabled " +
+            "WHEN migrating to Flamingock Community " +
+            "THEN should fail with the current strict validation")
+    void GIVEN_unknownAuditEntriesAndExplicitStrictMode_WHEN_migratingToFlamingockCommunity_THEN_shouldFail() {
+        Collection originCollection = cluster.bucket(MONGOCK_BUCKET_NAME).scope(MONGOCK_SCOPE_NAME).collection(MONGOCK_COLLECTION_NAME);
+
+        originCollection.upsert("mongock-change-1", createAuditObject("mongock-change-1"));
+        originCollection.upsert("foreign-change-1", createAuditObject("foreign-change-1", false, "io.example.foreign.ForeignChangeUnit", "apply"));
+
+        CouchbaseTargetSystem targetSystem = new CouchbaseTargetSystem("couchbase-target-system", cluster, FLAMINGOCK_BUCKET_NAME);
+
+        Runner flamingock = testKit.createBuilder()
+                .setAuditStore(auditStore)
+                .addTargetSystem(targetSystem)
+                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY, Boolean.FALSE.toString())
+                .build();
+
+        StagedExecuteOperationException ex = assertThrows(StagedExecuteOperationException.class, flamingock::run);
+        assertEquals("Error importing audit entry with changeId[foreign-change-1]: no matching change was found in the current Flamingock pipeline.",
+                firstFailedStageErrorMessage(ex));
+    }
+
+    @Test
+    @DisplayName("GIVEN Mongock audit history contains unknown entries " +
+            "AND relaxed import flag is enabled " +
+            "WHEN migrating to Flamingock Community " +
+            "THEN should skip the unknown entries and continue")
+    void GIVEN_unknownAuditEntriesAndRelaxedMode_WHEN_migratingToFlamingockCommunity_THEN_shouldSkipUnknownEntries() {
+        Collection originCollection = cluster.bucket(MONGOCK_BUCKET_NAME).scope(MONGOCK_SCOPE_NAME).collection(MONGOCK_COLLECTION_NAME);
+
+        originCollection.upsert("mongock-change-1", createAuditObject("mongock-change-1"));
+        originCollection.upsert("foreign-change-1", createAuditObject("foreign-change-1", false, "io.example.foreign.ForeignChangeUnit", "apply"));
+
+        CouchbaseTargetSystem targetSystem = new CouchbaseTargetSystem("couchbase-target-system", cluster, FLAMINGOCK_BUCKET_NAME);
+
+        Runner flamingock = testKit.createBuilder()
+                .setAuditStore(auditStore)
+                .addTargetSystem(targetSystem)
+                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY, Boolean.TRUE.toString())
+                .build();
+
+        flamingock.run();
+
+        auditHelper.verifyAuditSequenceStrict(
+                APPLIED("mongock-change-1"),
+                STARTED("migration-mongock-to-flamingock-community"),
+                APPLIED("migration-mongock-to-flamingock-community"),
+                STARTED("mongock-change-2"),
+                APPLIED("mongock-change-2"),
+                STARTED("flamingock-change"),
+                APPLIED("flamingock-change")
+        );
+    }
+
+    @Test
+    @DisplayName("GIVEN relaxed import flag with invalid value " +
+            "WHEN migrating to Flamingock Community " +
+            "THEN should throw exception")
+    void GIVEN_relaxedImportFlagWithInvalidValue_WHEN_migratingToFlamingockCommunity_THEN_shouldThrowException() {
+        Collection originCollection = cluster.bucket(MONGOCK_BUCKET_NAME).scope(MONGOCK_SCOPE_NAME).collection(MONGOCK_COLLECTION_NAME);
+        originCollection.upsert("foreign-change-1", createAuditObject("foreign-change-1", false, "io.example.foreign.ForeignChangeUnit", "apply"));
+
+        final String flagValue = "invalid_value";
+
+        CouchbaseTargetSystem targetSystem = new CouchbaseTargetSystem("couchbase-target-system", cluster, FLAMINGOCK_BUCKET_NAME);
+
+        Runner flamingock = testKit.createBuilder()
+                .setAuditStore(auditStore)
+                .addTargetSystem(targetSystem)
+                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY, flagValue)
+                .build();
+
+        StagedExecuteOperationException ex = assertThrows(StagedExecuteOperationException.class, flamingock::run);
+        assertEquals("Invalid value for " + MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY + ": " + flagValue
+                + " (expected \"true\" or \"false\" or empty)", firstFailedStageErrorMessage(ex));
+    }
+
+    @Test
     @DisplayName("GIVEN skip import flag with invalid value " +
             "WHEN migrating to Flamingock Community" +
             "THEN should throw exception")
@@ -481,6 +583,10 @@ public class CouchbaseImporterTest {
     }
 
     private static JsonObject createAuditObject(String value) {
+        return createAuditObject(value, true, "io.flamingock.changelog.Class1", "method1");
+    }
+
+    private static JsonObject createAuditObject(String value, boolean systemChange, String changeLogClass, String changeSetMethod) {
         JsonObject doc = JsonObject.create()
                 .put("executionId", "exec-1")
                 .put("changeId", value)
@@ -488,13 +594,13 @@ public class CouchbaseImporterTest {
                 .put("timestamp", Instant.now().toEpochMilli())
                 .put("state", "EXECUTED")
                 .put("type", "EXECUTION")
-                .put("changeLogClass", "io.flamingock.changelog.Class1")
-                .put("changeSetMethod", "method1")
+                .put("changeLogClass", changeLogClass)
+                .put("changeSetMethod", changeSetMethod)
                 .putNull("metadata")
                 .put("executionMillis", 123L)
                 .put("executionHostName", "host1")
                 .putNull("errorTrace")
-                .put("systemChange", true)
+                .put("systemChange", systemChange)
                 .put("_doctype", "mongockChangeEntry");
         return doc;
     }

--- a/legacy/mongock-importer-dynamodb/src/test/java/io/flamingock/importer/mongock/dynamodb/DynamoDBImporterTest.java
+++ b/legacy/mongock-importer-dynamodb/src/test/java/io/flamingock/importer/mongock/dynamodb/DynamoDBImporterTest.java
@@ -49,6 +49,7 @@ import static io.flamingock.core.kit.audit.AuditEntryExpectation.APPLIED;
 import static io.flamingock.core.kit.audit.AuditEntryExpectation.STARTED;
 import static io.flamingock.internal.common.core.metadata.Constants.DEFAULT_MONGOCK_ORIGIN;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY;
+import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_ORIGIN_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_SKIP_PROPERTY_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -348,6 +349,97 @@ public class DynamoDBImporterTest {
         );
         assertEquals("email", tableDescription.table().keySchema().get(0).attributeName());
         assertEquals(KeyType.HASH, tableDescription.table().keySchema().get(0).keyType());
+    }
+
+    @Test
+    @DisplayName("GIVEN Mongock audit history contains unknown entries " +
+            "AND relaxed import flag is not provided " +
+            "WHEN migrating to Flamingock Community " +
+            "THEN should fail with the current strict validation")
+    void GIVEN_unknownAuditEntriesAndImplicitStrictMode_WHEN_migratingToFlamingockCommunity_THEN_shouldFail() {
+        mongockTestHelper.setupWithUnknownChange();
+
+        DynamoDBTargetSystem dynamodbTargetSystem = new DynamoDBTargetSystem("dynamodb-target-system", client);
+
+        Runner flamingock = testKit.createBuilder()
+                .addTargetSystem(dynamodbTargetSystem)
+                .build();
+
+        StagedExecuteOperationException ex = assertThrows(StagedExecuteOperationException.class, flamingock::run);
+        assertEquals("Error importing audit entry with changeId[foreign-change-1]: no matching change was found in the current Flamingock pipeline.",
+                firstFailedStageErrorMessage(ex));
+    }
+
+    @Test
+    @DisplayName("GIVEN Mongock audit history contains unknown entries " +
+            "AND relaxed import flag is explicitly disabled " +
+            "WHEN migrating to Flamingock Community " +
+            "THEN should fail with the current strict validation")
+    void GIVEN_unknownAuditEntriesAndExplicitStrictMode_WHEN_migratingToFlamingockCommunity_THEN_shouldFail() {
+        mongockTestHelper.setupWithUnknownChange();
+
+        DynamoDBTargetSystem dynamodbTargetSystem = new DynamoDBTargetSystem("dynamodb-target-system", client);
+
+        Runner flamingock = testKit.createBuilder()
+                .addTargetSystem(dynamodbTargetSystem)
+                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY, Boolean.FALSE.toString())
+                .build();
+
+        StagedExecuteOperationException ex = assertThrows(StagedExecuteOperationException.class, flamingock::run);
+        assertEquals("Error importing audit entry with changeId[foreign-change-1]: no matching change was found in the current Flamingock pipeline.",
+                firstFailedStageErrorMessage(ex));
+    }
+
+    @Test
+    @DisplayName("GIVEN Mongock audit history contains unknown entries " +
+            "AND relaxed import flag is enabled " +
+            "WHEN migrating to Flamingock Community " +
+            "THEN should skip the unknown entries and continue")
+    void GIVEN_unknownAuditEntriesAndRelaxedMode_WHEN_migratingToFlamingockCommunity_THEN_shouldSkipUnknownEntries() {
+        mongockTestHelper.setupWithUnknownChange();
+
+        DynamoDBTargetSystem dynamodbTargetSystem = new DynamoDBTargetSystem("dynamodb-target-system", client);
+
+        Runner flamingock = testKit.createBuilder()
+                .addTargetSystem(dynamodbTargetSystem)
+                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY, Boolean.TRUE.toString())
+                .build();
+
+        flamingock.run();
+
+        auditHelper.verifyAuditSequenceStrict(
+                APPLIED("system-change-00001_before"),
+                APPLIED("system-change-00001"),
+                APPLIED("mongock-change-1_before"),
+                APPLIED("mongock-change-1"),
+                APPLIED("mongock-change-2"),
+                STARTED("migration-mongock-to-flamingock-community"),
+                APPLIED("migration-mongock-to-flamingock-community"),
+                STARTED("create-users-table"),
+                APPLIED("create-users-table")
+        );
+    }
+
+    @Test
+    @DisplayName("GIVEN relaxed import flag with invalid value " +
+            "WHEN migrating to Flamingock Community " +
+            "THEN should throw exception")
+    void GIVEN_relaxedImportFlagWithInvalidValue_WHEN_migratingToFlamingockCommunity_THEN_shouldThrowException() {
+        mongockTestHelper.setupWithUnknownChange();
+
+        DynamoDBTargetSystem dynamodbTargetSystem = new DynamoDBTargetSystem("dynamodb-target-system", client);
+
+        final String flagValue = "invalid_value";
+
+        Runner flamingock = testKit.createBuilder()
+                .addTargetSystem(dynamodbTargetSystem)
+                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY, flagValue)
+                .build();
+
+        StagedExecuteOperationException ex = assertThrows(StagedExecuteOperationException.class, flamingock::run);
+        assertEquals("Invalid value for " + MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY + ": " + flagValue
+                + " (expected \"true\" or \"false\" or empty)",
+                firstFailedStageErrorMessage(ex));
     }
 
     @Test

--- a/legacy/mongock-importer-dynamodb/src/test/java/io/flamingock/importer/mongock/dynamodb/DynamoDBImporterTest.java
+++ b/legacy/mongock-importer-dynamodb/src/test/java/io/flamingock/importer/mongock/dynamodb/DynamoDBImporterTest.java
@@ -49,7 +49,7 @@ import static io.flamingock.core.kit.audit.AuditEntryExpectation.APPLIED;
 import static io.flamingock.core.kit.audit.AuditEntryExpectation.STARTED;
 import static io.flamingock.internal.common.core.metadata.Constants.DEFAULT_MONGOCK_ORIGIN;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY;
-import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY;
+import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_ORIGIN_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_SKIP_PROPERTY_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -382,7 +382,7 @@ public class DynamoDBImporterTest {
 
         Runner flamingock = testKit.createBuilder()
                 .addTargetSystem(dynamodbTargetSystem)
-                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY, Boolean.FALSE.toString())
+                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY, Boolean.FALSE.toString())
                 .build();
 
         StagedExecuteOperationException ex = assertThrows(StagedExecuteOperationException.class, flamingock::run);
@@ -402,7 +402,7 @@ public class DynamoDBImporterTest {
 
         Runner flamingock = testKit.createBuilder()
                 .addTargetSystem(dynamodbTargetSystem)
-                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY, Boolean.TRUE.toString())
+                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY, Boolean.TRUE.toString())
                 .build();
 
         flamingock.run();
@@ -433,11 +433,11 @@ public class DynamoDBImporterTest {
 
         Runner flamingock = testKit.createBuilder()
                 .addTargetSystem(dynamodbTargetSystem)
-                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY, flagValue)
+                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY, flagValue)
                 .build();
 
         StagedExecuteOperationException ex = assertThrows(StagedExecuteOperationException.class, flamingock::run);
-        assertEquals("Invalid value for " + MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY + ": " + flagValue
+        assertEquals("Invalid value for " + MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY + ": " + flagValue
                 + " (expected \"true\" or \"false\" or empty)",
                 firstFailedStageErrorMessage(ex));
     }

--- a/legacy/mongock-importer-mongodb/src/test/java/io/flamingock/importer/mongock/mongodb/MongoDBImporterTest.java
+++ b/legacy/mongock-importer-mongodb/src/test/java/io/flamingock/importer/mongock/mongodb/MongoDBImporterTest.java
@@ -49,7 +49,7 @@ import static io.flamingock.core.kit.audit.AuditEntryExpectation.APPLIED;
 import static io.flamingock.core.kit.audit.AuditEntryExpectation.STARTED;
 import static io.flamingock.internal.common.core.metadata.Constants.DEFAULT_MONGOCK_ORIGIN;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY;
-import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY;
+import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_ORIGIN_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_SKIP_PROPERTY_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -404,7 +404,7 @@ public class MongoDBImporterTest {
 
         Runner flamingock = testKit.createBuilder()
                 .addTargetSystem(mongodbTargetSystem)
-                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY, Boolean.FALSE.toString())
+                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY, Boolean.FALSE.toString())
                 .build();
 
         StagedExecuteOperationException ex = assertThrows(StagedExecuteOperationException.class, flamingock::run);
@@ -424,7 +424,7 @@ public class MongoDBImporterTest {
 
         Runner flamingock = testKit.createBuilder()
                 .addTargetSystem(mongodbTargetSystem)
-                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY, Boolean.TRUE.toString())
+                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY, Boolean.TRUE.toString())
                 .build();
 
         flamingock.run();
@@ -457,11 +457,11 @@ public class MongoDBImporterTest {
 
         Runner flamingock = testKit.createBuilder()
                 .addTargetSystem(mongodbTargetSystem)
-                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY, flagValue)
+                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY, flagValue)
                 .build();
 
         StagedExecuteOperationException ex = assertThrows(StagedExecuteOperationException.class, flamingock::run);
-        assertEquals("Invalid value for " + MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY + ": " + flagValue
+        assertEquals("Invalid value for " + MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY + ": " + flagValue
                 + " (expected \"true\" or \"false\" or empty)",
                 firstFailedStageErrorMessage(ex));
     }

--- a/legacy/mongock-importer-mongodb/src/test/java/io/flamingock/importer/mongock/mongodb/MongoDBImporterTest.java
+++ b/legacy/mongock-importer-mongodb/src/test/java/io/flamingock/importer/mongock/mongodb/MongoDBImporterTest.java
@@ -49,6 +49,7 @@ import static io.flamingock.core.kit.audit.AuditEntryExpectation.APPLIED;
 import static io.flamingock.core.kit.audit.AuditEntryExpectation.STARTED;
 import static io.flamingock.internal.common.core.metadata.Constants.DEFAULT_MONGOCK_ORIGIN;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY;
+import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_ORIGIN_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_SKIP_PROPERTY_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -370,6 +371,99 @@ public class MongoDBImporterTest {
         Assertions.assertEquals("Backup", users.get(1).getString("name"));
         Assertions.assertEquals("backup@company.com", users.get(1).getString("email"));
         Assertions.assertEquals("readonly", users.get(1).getList("roles", String.class).get(0));
+    }
+
+    @Test
+    @DisplayName("GIVEN Mongock audit history contains unknown entries " +
+            "AND relaxed import flag is not provided " +
+            "WHEN migrating to Flamingock Community " +
+            "THEN should fail with the current strict validation")
+    void GIVEN_unknownAuditEntriesAndImplicitStrictMode_WHEN_migratingToFlamingockCommunity_THEN_shouldFail() {
+        mongockTestHelper.setupWithUnknownChange();
+
+        MongoDBSyncTargetSystem mongodbTargetSystem = new MongoDBSyncTargetSystem("mongodb-target-system", mongoClient, DATABASE_NAME);
+
+        Runner flamingock = testKit.createBuilder()
+                .addTargetSystem(mongodbTargetSystem)
+                .build();
+
+        StagedExecuteOperationException ex = assertThrows(StagedExecuteOperationException.class, flamingock::run);
+        assertEquals("Error importing audit entry with changeId[foreign-change-1]: no matching change was found in the current Flamingock pipeline.",
+                firstFailedStageErrorMessage(ex));
+    }
+
+    @Test
+    @DisplayName("GIVEN Mongock audit history contains unknown entries " +
+            "AND relaxed import flag is explicitly disabled " +
+            "WHEN migrating to Flamingock Community " +
+            "THEN should fail with the current strict validation")
+    void GIVEN_unknownAuditEntriesAndExplicitStrictMode_WHEN_migratingToFlamingockCommunity_THEN_shouldFail() {
+        mongockTestHelper.setupWithUnknownChange();
+
+        MongoDBSyncTargetSystem mongodbTargetSystem = new MongoDBSyncTargetSystem("mongodb-target-system", mongoClient, DATABASE_NAME);
+
+        Runner flamingock = testKit.createBuilder()
+                .addTargetSystem(mongodbTargetSystem)
+                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY, Boolean.FALSE.toString())
+                .build();
+
+        StagedExecuteOperationException ex = assertThrows(StagedExecuteOperationException.class, flamingock::run);
+        assertEquals("Error importing audit entry with changeId[foreign-change-1]: no matching change was found in the current Flamingock pipeline.",
+                firstFailedStageErrorMessage(ex));
+    }
+
+    @Test
+    @DisplayName("GIVEN Mongock audit history contains unknown entries " +
+            "AND relaxed import flag is enabled " +
+            "WHEN migrating to Flamingock Community " +
+            "THEN should skip the unknown entries and continue")
+    void GIVEN_unknownAuditEntriesAndRelaxedMode_WHEN_migratingToFlamingockCommunity_THEN_shouldSkipUnknownEntries() {
+        mongockTestHelper.setupWithUnknownChange();
+
+        MongoDBSyncTargetSystem mongodbTargetSystem = new MongoDBSyncTargetSystem("mongodb-target-system", mongoClient, DATABASE_NAME);
+
+        Runner flamingock = testKit.createBuilder()
+                .addTargetSystem(mongodbTargetSystem)
+                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY, Boolean.TRUE.toString())
+                .build();
+
+        flamingock.run();
+
+        auditHelper.verifyAuditSequenceStrict(
+                APPLIED("system-change-00001_before"),
+                APPLIED("system-change-00001"),
+                APPLIED("mongock-change-1_before"),
+                APPLIED("mongock-change-1"),
+                APPLIED("mongock-change-2"),
+                STARTED("migration-mongock-to-flamingock-community"),
+                APPLIED("migration-mongock-to-flamingock-community"),
+                STARTED("create-users-collection-with-index"),
+                APPLIED("create-users-collection-with-index"),
+                STARTED("seed-users"),
+                APPLIED("seed-users")
+        );
+    }
+
+    @Test
+    @DisplayName("GIVEN relaxed import flag with invalid value " +
+            "WHEN migrating to Flamingock Community " +
+            "THEN should throw exception")
+    void GIVEN_relaxedImportFlagWithInvalidValue_WHEN_migratingToFlamingockCommunity_THEN_shouldThrowException() {
+        mongockTestHelper.setupWithUnknownChange();
+
+        MongoDBSyncTargetSystem mongodbTargetSystem = new MongoDBSyncTargetSystem("mongodb-target-system", mongoClient, DATABASE_NAME);
+
+        final String flagValue = "invalid_value";
+
+        Runner flamingock = testKit.createBuilder()
+                .addTargetSystem(mongodbTargetSystem)
+                .setProperty(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY, flagValue)
+                .build();
+
+        StagedExecuteOperationException ex = assertThrows(StagedExecuteOperationException.class, flamingock::run);
+        assertEquals("Invalid value for " + MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY + ": " + flagValue
+                + " (expected \"true\" or \"false\" or empty)",
+                firstFailedStageErrorMessage(ex));
     }
 
     @Test

--- a/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/MongockImportChange.java
+++ b/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/MongockImportChange.java
@@ -50,10 +50,11 @@ public class MongockImportChange {
                               @NonLockGuarded TargetSystemManager targetSystemManager,
                               @NonLockGuarded AuditWriter auditWriter,
                               @NonLockGuarded PipelineDescriptor pipelineDescriptor,
-                              @Nullable @Named(MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY) String emptyOriginAllowed,
-                              @Nullable @Named(MONGOCK_IMPORT_SKIP_PROPERTY_KEY) String skipImport,
-                              @Nullable @Named(MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY) String ignoreUnknownEntriesRaw) {
-        if (resolveSkipImport(skipImport)) {
+                              @Nullable @Named(MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY) String emptyOriginAllowedPropertyValue,
+                              @Nullable @Named(MONGOCK_IMPORT_SKIP_PROPERTY_KEY) String skipImportPropertyValue,
+                              @Nullable @Named(MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY) String ignoreUnknownEntriesPropertyValue) {
+        boolean skipImport = resolveSkipImport(skipImportPropertyValue);
+        if (skipImport) {
             logger.info("Mongock audit log import skipped (skipImport=true). No audit entries will be migrated.");
             return;
         }
@@ -61,8 +62,8 @@ public class MongockImportChange {
         AuditHistoryReader legacyHistoryReader = getAuditHistoryReader(targetSystemId, targetSystemManager);
         PipelineHelper pipelineHelper = new PipelineHelper(pipelineDescriptor);
         List<AuditEntry> legacyHistory = legacyHistoryReader.getAuditHistory();
-        boolean ignoreUnknownEntries = resolveIgnoreUnknownEntries(ignoreUnknownEntriesRaw);
-        validate(legacyHistory, targetSystemId, emptyOriginAllowed);
+        boolean ignoreUnknownEntries = resolveIgnoreUnknownEntries(ignoreUnknownEntriesPropertyValue);
+        validate(legacyHistory, targetSystemId, emptyOriginAllowedPropertyValue);
         legacyHistory.forEach(auditEntryFromOrigin -> {
             Optional<String> stageId = pipelineHelper.findStageId(auditEntryFromOrigin);
             if (!stageId.isPresent()) {

--- a/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/MongockImportChange.java
+++ b/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/MongockImportChange.java
@@ -31,9 +31,11 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Named;
 import java.util.List;
+import java.util.Optional;
 
 import static io.flamingock.internal.common.core.audit.AuditReaderType.MONGOCK;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY;
+import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_SKIP_PROPERTY_KEY;
 
 /**
@@ -49,7 +51,8 @@ public class MongockImportChange {
                               @NonLockGuarded AuditWriter auditWriter,
                               @NonLockGuarded PipelineDescriptor pipelineDescriptor,
                               @Nullable @Named(MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY) String emptyOriginAllowed,
-                              @Nullable @Named(MONGOCK_IMPORT_SKIP_PROPERTY_KEY) String skipImport) {
+                              @Nullable @Named(MONGOCK_IMPORT_SKIP_PROPERTY_KEY) String skipImport,
+                              @Nullable @Named(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY) String ignoreUnknownAuditEntries) {
         if (resolveSkipImport(skipImport)) {
             logger.info("Mongock audit log import skipped (skipImport=true). No audit entries will be migrated.");
             return;
@@ -58,12 +61,26 @@ public class MongockImportChange {
         AuditHistoryReader legacyHistoryReader = getAuditHistoryReader(targetSystemId, targetSystemManager);
         PipelineHelper pipelineHelper = new PipelineHelper(pipelineDescriptor);
         List<AuditEntry> legacyHistory = legacyHistoryReader.getAuditHistory();
+        boolean ignoreUnknownEntries = resolveIgnoreUnknownAuditEntries(ignoreUnknownAuditEntries);
         validate(legacyHistory, targetSystemId, emptyOriginAllowed);
         legacyHistory.forEach(auditEntryFromOrigin -> {
+            Optional<String> stageId = pipelineHelper.findStageId(auditEntryFromOrigin);
+            if (!stageId.isPresent()) {
+                if (ignoreUnknownEntries) {
+                    logger.warn("Ignored audit entry with changeId[{}] while importing audit history: no matching change was found in the current Flamingock pipeline. changeLogClass[{}], changeSetMethod[{}]",
+                            auditEntryFromOrigin.getChangeId(),
+                            auditEntryFromOrigin.getClassName(),
+                            auditEntryFromOrigin.getMethodName());
+                    return;
+                }
+                throw new FlamingockException(String.format(
+                        "Error importing audit entry with changeId[%s]: no matching change was found in the current Flamingock pipeline.",
+                        pipelineHelper.getBaseChangeId(auditEntryFromOrigin)));
+            }
             //This is the changeId present in the pipeline. If it's a system change or '..._before' won't appear
             AuditEntry auditEntryWithStageId = auditEntryFromOrigin.copyWithNewIdAndStageId(
                     pipelineHelper.getStorableChangeId(auditEntryFromOrigin),
-                    pipelineHelper.getStageId(auditEntryFromOrigin));
+                    stageId.get());
             auditWriter.writeEntry(auditEntryWithStageId);
         });
     }
@@ -98,24 +115,25 @@ public class MongockImportChange {
     }
 
     private boolean resolveEmptyOriginAllowed(String raw) {
-        if (raw == null || raw.trim().isEmpty()) {
-            return false; // default behaviour
-        }
-        String v = raw.trim();
-        if ("true".equalsIgnoreCase(v)) return true;
-        if ("false".equalsIgnoreCase(v)) return false;
-        throw new FlamingockException("Invalid value for " +  MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY + ": " + raw
-                + " (expected \"true\" or \"false\" or empty)");
+        return resolveBooleanPropertyValue(raw, MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY);
     }
 
     private boolean resolveSkipImport(String raw) {
+        return resolveBooleanPropertyValue(raw, MONGOCK_IMPORT_SKIP_PROPERTY_KEY);
+    }
+
+    private boolean resolveIgnoreUnknownAuditEntries(String raw) {
+        return resolveBooleanPropertyValue(raw, MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY);
+    }
+
+    private boolean resolveBooleanPropertyValue(String raw, String propertyName) {
         if (raw == null || raw.trim().isEmpty()) {
             return false; // default behaviour
         }
         String v = raw.trim();
         if ("true".equalsIgnoreCase(v)) return true;
         if ("false".equalsIgnoreCase(v)) return false;
-        throw new FlamingockException("Invalid value for " + MONGOCK_IMPORT_SKIP_PROPERTY_KEY + ": " + raw
+        throw new FlamingockException("Invalid value for " + propertyName + ": " + raw
                 + " (expected \"true\" or \"false\" or empty)");
     }
 }

--- a/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/MongockImportChange.java
+++ b/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/MongockImportChange.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 
 import static io.flamingock.internal.common.core.audit.AuditReaderType.MONGOCK;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY;
-import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY;
+import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_SKIP_PROPERTY_KEY;
 
 /**
@@ -52,7 +52,7 @@ public class MongockImportChange {
                               @NonLockGuarded PipelineDescriptor pipelineDescriptor,
                               @Nullable @Named(MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY) String emptyOriginAllowed,
                               @Nullable @Named(MONGOCK_IMPORT_SKIP_PROPERTY_KEY) String skipImport,
-                              @Nullable @Named(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY) String ignoreUnknownAuditEntries) {
+                              @Nullable @Named(MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY) String ignoreUnknownEntries) {
         if (resolveSkipImport(skipImport)) {
             logger.info("Mongock audit log import skipped (skipImport=true). No audit entries will be migrated.");
             return;
@@ -61,7 +61,7 @@ public class MongockImportChange {
         AuditHistoryReader legacyHistoryReader = getAuditHistoryReader(targetSystemId, targetSystemManager);
         PipelineHelper pipelineHelper = new PipelineHelper(pipelineDescriptor);
         List<AuditEntry> legacyHistory = legacyHistoryReader.getAuditHistory();
-        boolean ignoreUnknownEntries = resolveIgnoreUnknownAuditEntries(ignoreUnknownAuditEntries);
+        boolean ignoreUnknownEntries = resolveIgnoreUnknownEntries(ignoreUnknownEntries);
         validate(legacyHistory, targetSystemId, emptyOriginAllowed);
         legacyHistory.forEach(auditEntryFromOrigin -> {
             Optional<String> stageId = pipelineHelper.findStageId(auditEntryFromOrigin);
@@ -122,8 +122,8 @@ public class MongockImportChange {
         return resolveBooleanPropertyValue(raw, MONGOCK_IMPORT_SKIP_PROPERTY_KEY);
     }
 
-    private boolean resolveIgnoreUnknownAuditEntries(String raw) {
-        return resolveBooleanPropertyValue(raw, MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY);
+    private boolean resolveIgnoreUnknownEntries(String raw) {
+        return resolveBooleanPropertyValue(raw, MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY);
     }
 
     private boolean resolveBooleanPropertyValue(String raw, String propertyName) {

--- a/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/MongockImportChange.java
+++ b/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/MongockImportChange.java
@@ -52,7 +52,7 @@ public class MongockImportChange {
                               @NonLockGuarded PipelineDescriptor pipelineDescriptor,
                               @Nullable @Named(MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY) String emptyOriginAllowed,
                               @Nullable @Named(MONGOCK_IMPORT_SKIP_PROPERTY_KEY) String skipImport,
-                              @Nullable @Named(MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY) String ignoreUnknownEntries) {
+                              @Nullable @Named(MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY) String ignoreUnknownEntriesRaw) {
         if (resolveSkipImport(skipImport)) {
             logger.info("Mongock audit log import skipped (skipImport=true). No audit entries will be migrated.");
             return;
@@ -61,7 +61,7 @@ public class MongockImportChange {
         AuditHistoryReader legacyHistoryReader = getAuditHistoryReader(targetSystemId, targetSystemManager);
         PipelineHelper pipelineHelper = new PipelineHelper(pipelineDescriptor);
         List<AuditEntry> legacyHistory = legacyHistoryReader.getAuditHistory();
-        boolean ignoreUnknownEntries = resolveIgnoreUnknownEntries(ignoreUnknownEntries);
+        boolean ignoreUnknownEntries = resolveIgnoreUnknownEntries(ignoreUnknownEntriesRaw);
         validate(legacyHistory, targetSystemId, emptyOriginAllowed);
         legacyHistory.forEach(auditEntryFromOrigin -> {
             Optional<String> stageId = pipelineHelper.findStageId(auditEntryFromOrigin);

--- a/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/annotations/MongockSupport.java
+++ b/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/annotations/MongockSupport.java
@@ -127,4 +127,20 @@ public @interface MongockSupport {
      * @return {@code "true"} to allow empty origin, {@code "false"} to fail; empty treated as {@code "false"}
      */
     String emptyOriginAllowed() default "";
+
+    /**
+     * Determines whether Flamingock should skip imported Mongock audit entries that do not
+     * match any change in the current Flamingock pipeline.
+     * <p>
+     * Expected literal values are {@code "true"} or {@code "false"}.
+     * </p>
+     *
+     * <p>
+     * If empty (default), it will be treated as {@code "false"} and Flamingock will preserve
+     * the current strict behaviour.
+     * </p>
+     *
+     * @return {@code "true"} to skip unknown imported entries, {@code "false"} to fail; empty treated as {@code "false"}
+     */
+    String ignoreUnknownAuditEntries() default "";
 }

--- a/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/annotations/MongockSupport.java
+++ b/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/annotations/MongockSupport.java
@@ -142,5 +142,5 @@ public @interface MongockSupport {
      *
      * @return {@code "true"} to skip unknown imported entries, {@code "false"} to fail; empty treated as {@code "false"}
      */
-    String ignoreUnknownAuditEntries() default "";
+    String ignoreUnknownEntries() default "";
 }

--- a/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/processor/MongockAnnotationProcessorPlugin.java
+++ b/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/processor/MongockAnnotationProcessorPlugin.java
@@ -52,7 +52,7 @@ import java.util.stream.Stream;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_SKIP_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_ORIGIN_PROPERTY_KEY;
-import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY;
+import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY;
 
 @SuppressWarnings("deprecation")
 public class MongockAnnotationProcessorPlugin implements AnnotationProcessorPlugin, ChangeDiscoverer, ConfigurationPropertiesProvider {
@@ -167,10 +167,10 @@ public class MongockAnnotationProcessorPlugin implements AnnotationProcessorPlug
         }
 
         // Ignore Unknown Audit Entries
-        ConfigValueParser.ConfigValue ignoreUnknownAuditEntriesValue =
-                ConfigValueParser.parse("ignoreUnknownAuditEntries", mongockSupport.ignoreUnknownAuditEntries(), ConfigValueParser.BOOLEAN_VALUE_VALIDATOR);
-        if (!ignoreUnknownAuditEntriesValue.isEmpty()) {
-            properties.put(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY, ignoreUnknownAuditEntriesValue.getRaw());
+        ConfigValueParser.ConfigValue ignoreUnknownEntriesValue =
+                ConfigValueParser.parse("ignoreUnknownEntries", mongockSupport.ignoreUnknownEntries(), ConfigValueParser.BOOLEAN_VALUE_VALIDATOR);
+        if (!ignoreUnknownEntriesValue.isEmpty()) {
+            properties.put(MONGOCK_IMPORT_IGNORE_UNKNOWN_ENTRIES_PROPERTY_KEY, ignoreUnknownEntriesValue.getRaw());
         }
     }
 }

--- a/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/processor/MongockAnnotationProcessorPlugin.java
+++ b/legacy/mongock-support/src/main/java/io/flamingock/support/mongock/processor/MongockAnnotationProcessorPlugin.java
@@ -52,6 +52,7 @@ import java.util.stream.Stream;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_EMPTY_ORIGIN_ALLOWED_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_SKIP_PROPERTY_KEY;
 import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_ORIGIN_PROPERTY_KEY;
+import static io.flamingock.internal.common.core.metadata.Constants.MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY;
 
 @SuppressWarnings("deprecation")
 public class MongockAnnotationProcessorPlugin implements AnnotationProcessorPlugin, ChangeDiscoverer, ConfigurationPropertiesProvider {
@@ -163,6 +164,13 @@ public class MongockAnnotationProcessorPlugin implements AnnotationProcessorPlug
                 ConfigValueParser.parse("origin", mongockSupport.origin());
         if (!originValue.isEmpty()) {
             properties.put(MONGOCK_IMPORT_ORIGIN_PROPERTY_KEY, originValue.getRaw());
+        }
+
+        // Ignore Unknown Audit Entries
+        ConfigValueParser.ConfigValue ignoreUnknownAuditEntriesValue =
+                ConfigValueParser.parse("ignoreUnknownAuditEntries", mongockSupport.ignoreUnknownAuditEntries(), ConfigValueParser.BOOLEAN_VALUE_VALIDATOR);
+        if (!ignoreUnknownAuditEntriesValue.isEmpty()) {
+            properties.put(MONGOCK_IMPORT_IGNORE_UNKNOWN_AUDIT_ENTRIES_PROPERTY_KEY, ignoreUnknownAuditEntriesValue.getRaw());
         }
     }
 }

--- a/utils/test-util/src/main/java/io/flamingock/common/test/mongock/MongockTestHelper.java
+++ b/utils/test-util/src/main/java/io/flamingock/common/test/mongock/MongockTestHelper.java
@@ -235,4 +235,30 @@ public interface MongockTestHelper {
             throw new RuntimeException("Failed to parse date", e);
         }
     }
+
+    default int setupWithUnknownChange() {
+        int writtenEntries = setupBasicScenario();
+
+        try {
+            write(new MongockChangeEntry(
+                    DEFAULT_EXECUTION_ID,
+                    "foreign-change-1",
+                    "mongock",
+                    DEFAULT_DATE_FORMAT.parse("2025-06-19T05:43:57.190Z"),
+                    MongockChangeState.EXECUTED,
+                    MongockChangeType.EXECUTION,
+                    "io.example.foreign.ForeignChangeUnit",
+                    "apply",
+                    null,
+                    15L,
+                    DEFAULT_HOSTNAME,
+                    null,
+                    false,
+                    null
+            ));
+            return writtenEntries + 1;
+        } catch (ParseException e) {
+            throw new RuntimeException("Failed to parse date", e);
+        }
+    }
 }


### PR DESCRIPTION
Add a new @MongockSupport flag, ignoreUnknownAuditEntries, to relax legacy Mongock audit import when the origin contains entries that do not match any change in the current Flamingock pipeline.

- add the new annotation field and internal property key
- propagate the flag through the Mongock annotation processor
- resolve unknown legacy entries through PipelineHelper.findStageId
- ignore unmatched entries in relaxed mode with a warning
- fail in strict mode with clearer import-specific messaging
- add unit and importer test coverage for strict and relaxed scenarios