### PR TITLE
fix(core): report supported source version dynamically in annotation processor

### DIFF
--- a/core/flamingock-processor/src/main/java/io/flamingock/core/processor/FlamingockAnnotationProcessor.java
+++ b/core/flamingock-processor/src/main/java/io/flamingock/core/processor/FlamingockAnnotationProcessor.java
@@ -36,7 +36,6 @@ import org.jetbrains.annotations.NotNull;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.TypeElement;
 import java.io.File;
@@ -118,7 +117,6 @@ import java.util.regex.Pattern;
  * @version 2.0
  * @since Flamingock v1.x
  */
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class FlamingockAnnotationProcessor extends AbstractProcessor {
 
     private static final String RESOURCES_PATH_ARG = "flamingock.resources";
@@ -165,6 +163,11 @@ public class FlamingockAnnotationProcessor extends AbstractProcessor {
                 Change.class.getName(),
                 FlamingockCliBuilder.class.getName()
         ));
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
     }
 
     @Override


### PR DESCRIPTION
- Replace the fixed `@SupportedSourceVersion(SourceVersion.RELEASE_8)` declaration with a dynamic `getSupportedSourceVersion()` override.
- Make the annotation processor report the runtime JDK source level through `SourceVersion.latestSupported()`.
- Eliminate the Java 25 warning about the processor supporting a lower source version than the build.
