### PR TITLE
build(dependencies): minimize consumer dependency footprint

### DIFF
--- a/buildSrc/src/main/kotlin/flamingock.publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/flamingock.publishing.gradle.kts
@@ -1,3 +1,6 @@
+import groovy.util.Node
+import org.gradle.api.artifacts.ExternalModuleDependency
+
 plugins {
     `maven-publish`
     id("org.jreleaser")
@@ -11,6 +14,15 @@ fun Project.isLibraryModule(): Boolean = name !in setOf(
 
 val fromComponentPublishing = if (isBomModule()) "javaPlatform" else "java"
 val mavenPublication = if (isBomModule()) "communityBom" else "maven"
+val externalCompileOnlyApiDependencies = provider {
+    configurations.findByName("compileOnlyApi")
+        ?.dependencies
+        ?.filterIsInstance<ExternalModuleDependency>()
+        ?.filter { dependency -> dependency.group != "io.flamingock" }
+        ?.map { dependency -> "${dependency.group}:${dependency.name}" }
+        ?.toSet()
+        ?: emptySet()
+}
 
 publishing {
     publications {
@@ -20,6 +32,31 @@ publishing {
             version = project.version.toString()
             from(components[fromComponentPublishing])
             pom {
+                withXml {
+                    val optionalDependencies = externalCompileOnlyApiDependencies.get()
+                    val dependencies = (asNode().get("dependencies") as List<*>)
+                        .filterIsInstance<Node>()
+                        .flatMap { dependenciesNode ->
+                            (dependenciesNode.get("dependency") as List<*>).filterIsInstance<Node>()
+                        }
+
+                    dependencies
+                        .filter { dependency ->
+                            val groupId = (dependency.get("groupId") as List<*>)
+                                .filterIsInstance<Node>()
+                                .firstOrNull()
+                                ?.text()
+                            val artifactId = (dependency.get("artifactId") as List<*>)
+                                .filterIsInstance<Node>()
+                                .firstOrNull()
+                                ?.text()
+                            "$groupId:$artifactId" in optionalDependencies
+                        }
+                        .filter { dependency ->
+                            (dependency.get("optional") as List<*>).isEmpty()
+                        }
+                        .forEach { dependency -> dependency.appendNode("optional", "true") }
+                }
                 name.set(project.name)
                 description.set("Flamingock is a Java library that brings Change-as-Code to your applications. It enables you to define and apply versioned, auditable changes to databases, event schemas, and external systems, ensuring safety, synchronization, and governance at runtime")
                 url.set("https://www.flamingock.io")

--- a/cloud/flamingock-cloud/build.gradle.kts
+++ b/cloud/flamingock-cloud/build.gradle.kts
@@ -1,9 +1,7 @@
-val coreApiVersion: String by extra
 dependencies {
 // Core
     api(project(":cloud:flamingock-cloud-api"))
-    implementation(project(":core:flamingock-core"))
-    api("io.flamingock:flamingock-core-api:${coreApiVersion}")
+    api(project(":core:flamingock-core"))
 // target systems
     api(project(":core:target-systems:flamingock-nontransactional-targetsystem"))
     api(project(":core:target-systems:flamingock-couchbase-targetsystem"))
@@ -22,8 +20,10 @@ dependencies {
     api(project(":community:flamingock-mongodb-sync-auditstore"))
     api(project(":community:flamingock-sql-auditstore"))
 
+    implementation("org.apache.httpcomponents:httpclient:4.5.14")
 
- // Test
+     // Test
+    testImplementation("com.github.tomakehurst:wiremock-jre8:2.35.2")
     testAnnotationProcessor(project(":core:flamingock-processor"))
     testImplementation(project(":utils:test-util"))
     testImplementation(project(":core:target-systems:flamingock-nontransactional-targetsystem"))

--- a/community/flamingock-community-bom/build.gradle.kts
+++ b/community/flamingock-community-bom/build.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
         api("io.flamingock:flamingock-community:${version}")
         api("io.flamingock:flamingock-mongodb-reactive-auditstore:$version")
         api("io.flamingock:flamingock-mongodb-sync-auditstore:$version")
-        api("io.flamingock:flamingock-mongodb-springdata-auditstore:${version}")
         api("io.flamingock:flamingock-couchbase-auditstore:$version")
         api("io.flamingock:flamingock-dynamodb-auditstore:$version")
         api("io.flamingock:flamingock-sql-auditstore:$version")

--- a/community/flamingock-community/build.gradle.kts
+++ b/community/flamingock-community/build.gradle.kts
@@ -1,8 +1,4 @@
-val coreApiVersion: String by extra
 dependencies {
-// Core
-    api(project(":core:flamingock-core"))
-    api("io.flamingock:flamingock-core-api:${coreApiVersion}")
 // target systems
     api(project(":core:target-systems:flamingock-nontransactional-targetsystem"))
     api(project(":core:target-systems:flamingock-couchbase-targetsystem"))

--- a/community/flamingock-dynamodb-auditstore/build.gradle.kts
+++ b/community/flamingock-dynamodb-auditstore/build.gradle.kts
@@ -1,8 +1,6 @@
 dependencies {
     implementation(project(":utils:dynamodb-util"))
-    implementation(project(":core:flamingock-core"))
-
-
+    api(project(":core:flamingock-core"))
     api(project(":core:target-systems:flamingock-dynamodb-externalsystem-api"))
 
     compileOnly("software.amazon.awssdk:dynamodb-enhanced:2.25.29")

--- a/community/flamingock-mongodb-reactive-auditstore/build.gradle.kts
+++ b/community/flamingock-mongodb-reactive-auditstore/build.gradle.kts
@@ -1,14 +1,14 @@
 import org.jetbrains.kotlin.gradle.utils.extendsFrom
 
 dependencies {
-    implementation(project(":utils:mongodb-util"))
+    api(project(":utils:mongodb-util"))
     implementation(project(":utils:mongodb-reactive-util"))
     implementation(project(":utils:flamingock-reactive-util"))
-    implementation(project(":core:flamingock-core"))
+    api(project(":core:flamingock-core"))
     
     api(project(":core:target-systems:flamingock-mongodb-reactive-externalsystem-api"))
 
-    compileOnly("org.mongodb:mongodb-driver-reactivestreams:4.0.0")
+    compileOnlyApi("org.mongodb:mongodb-driver-reactivestreams:4.0.0")
 
     testImplementation(project(":utils:test-util"))
     testImplementation(project(":utils:mongodb-reactive-test-kit"))

--- a/community/flamingock-mongodb-sync-auditstore/build.gradle.kts
+++ b/community/flamingock-mongodb-sync-auditstore/build.gradle.kts
@@ -1,14 +1,14 @@
 import org.jetbrains.kotlin.gradle.utils.extendsFrom
 
 dependencies {
-    implementation(project(":utils:mongodb-util"))
+    api(project(":utils:mongodb-util"))
     implementation(project(":utils:mongodb-sync-util"))
-    implementation(project(":core:flamingock-core"))
+    api(project(":core:flamingock-core"))
 
     api(project(":core:target-systems:flamingock-mongodb-externalsystem-api"))
 //    api(project(":community:flamingock-community"))
 
-    compileOnly("org.mongodb:mongodb-driver-sync:4.0.0")
+    compileOnlyApi("org.mongodb:mongodb-driver-sync:4.0.0")
 
 
     testImplementation(project(":utils:test-util"))

--- a/community/flamingock-sql-auditstore/build.gradle.kts
+++ b/community/flamingock-sql-auditstore/build.gradle.kts
@@ -3,11 +3,10 @@ import java.time.Duration
 val sqlVersion: String by extra
 
 dependencies {
-    api(project(":core:flamingock-core"))
-
     api(project(":core:target-systems:flamingock-sql-externalsystem-api"))
 
-    api(project(":core:target-systems:flamingock-sql-targetsystem"))
+    api(project(":core:flamingock-core"))
+    implementation(project(":core:target-systems:flamingock-sql-targetsystem"))
     implementation("io.flamingock:flamingock-sql-util:${sqlVersion}")
 
     testImplementation(project(":core:target-systems:flamingock-sql-externalsystem-api"))
@@ -65,4 +64,3 @@ tasks.test {
         showStandardStreams = false
     }
 }
-

--- a/core/flamingock-bom/build.gradle.kts
+++ b/core/flamingock-bom/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
         api("io.flamingock:flamingock-community:${version}")
         api("io.flamingock:flamingock-mongodb-reactive-auditstore:$version")
         api("io.flamingock:flamingock-mongodb-sync-auditstore:$version")
-        api("io.flamingock:flamingock-mongodb-springdata-auditstore:${version}")
         api("io.flamingock:flamingock-couchbase-auditstore:$version")
         api("io.flamingock:flamingock-dynamodb-auditstore:$version")
         api("io.flamingock:flamingock-sql-auditstore:$version")

--- a/core/flamingock-core-commons/build.gradle.kts
+++ b/core/flamingock-core-commons/build.gradle.kts
@@ -4,8 +4,8 @@ val coreApiVersion: String by extra
 dependencies {
 //    api(project(":cloud:flamingock-cloud-api"))
     api("io.flamingock:flamingock-core-api:${coreApiVersion}")
-    api("io.flamingock:flamingock-general-util:${generalUtilVersion}")//todo implementation
-    api("jakarta.annotation:jakarta.annotation-api:2.1.1")//todo can this be implementation?
+    api("io.flamingock:flamingock-general-util:${generalUtilVersion}")
+    implementation("jakarta.annotation:jakarta.annotation-api:2.1.1")
 
     implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
     implementation("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")

--- a/core/flamingock-core/build.gradle.kts
+++ b/core/flamingock-core/build.gradle.kts
@@ -1,19 +1,17 @@
 val jacksonVersion = "2.16.0"
-val generalUtilVersion: String by extra
 
 dependencies {
     api(project(":core:flamingock-core-commons"))
-    api("io.flamingock:flamingock-general-util:${generalUtilVersion}")//todo implementation
 
-    api("javax.inject:javax.inject:1")
-    api("org.javassist:javassist:3.30.2-GA")
-    api("com.google.code.findbugs:jsr305:3.0.2")
-    api("org.objenesis:objenesis:3.2")
-    api("org.yaml:snakeyaml:2.2")
+    implementation("javax.inject:javax.inject:1")
+    implementation("org.javassist:javassist:3.30.2-GA")
+    implementation("com.google.code.findbugs:jsr305:3.0.2")
+    implementation("org.objenesis:objenesis:3.2")
+    implementation("org.yaml:snakeyaml:2.2")
 
-    api("org.apache.httpcomponents:httpclient:4.5.14")
+    implementation("org.apache.httpcomponents:httpclient:4.5.14")
     
-    api("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
+    implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
 
 
     testImplementation(project(":utils:test-util"))

--- a/core/flamingock-graalvm/build.gradle.kts
+++ b/core/flamingock-graalvm/build.gradle.kts
@@ -1,10 +1,10 @@
 val generalUtilVersion: String by extra
 dependencies {
-    api("io.flamingock:flamingock-general-util:${generalUtilVersion}")
+    implementation("io.flamingock:flamingock-general-util:${generalUtilVersion}")
 
     // GraalVM SDK for native image support — compileOnly because it's only needed at
     // native-image build time, never at JVM runtime.
-    compileOnly("org.graalvm.sdk:graal-sdk:22.3.0")
+    compileOnlyApi("org.graalvm.sdk:graal-sdk:22.3.0")
 }
 
 description = "GraalVM native image support and configuration for Flamingock applications"

--- a/core/flamingock-processor/build.gradle.kts
+++ b/core/flamingock-processor/build.gradle.kts
@@ -1,10 +1,8 @@
 val jacksonVersion = "2.16.0"
-val generalUtilVersion: String by extra
 dependencies {
     api(project(":core:flamingock-core-commons"))
-    api("io.flamingock:flamingock-general-util:${generalUtilVersion}")//todo implementation
-    api("org.yaml:snakeyaml:2.2")//todo implementation
-    api("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")//todo implementation
+    implementation("org.yaml:snakeyaml:2.2")
+    implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
 }
 
 description = "Annotation processor for generating change metadata and pipeline configurations from @Change annotations and YAML templates"

--- a/core/flamingock-test-support/build.gradle.kts
+++ b/core/flamingock-test-support/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    implementation(project(":core:flamingock-core"))
+    api(project(":core:flamingock-core"))
 
 
     testImplementation(platform("org.junit:junit-bom:5.10.0"))
@@ -9,7 +9,7 @@ dependencies {
     // Add test utilities from the repository so tests can use InMemoryTestKit and pipeline helpers
     testImplementation(project(":utils:test-util"))
     testImplementation(project(":core:target-systems:flamingock-nontransactional-targetsystem"))
-    api("org.mockito:mockito-inline:4.11.0")
+    implementation("org.mockito:mockito-inline:4.11.0")
 }
 
 description = "Test support module for Flamingock framework"

--- a/core/target-systems/flamingock-couchbase-externalsystem-api/build.gradle.kts
+++ b/core/target-systems/flamingock-couchbase-externalsystem-api/build.gradle.kts
@@ -1,9 +1,9 @@
 val coreApiVersion: String by extra
 dependencies {
-    implementation("io.flamingock:flamingock-core-api:${coreApiVersion}")
+    api("io.flamingock:flamingock-core-api:${coreApiVersion}")
 
     //General
-    compileOnly("com.couchbase.client:java-client:3.6.0")
+    compileOnlyApi("com.couchbase.client:java-client:3.6.0")
 }
 
 description = "Couchbase external system api"

--- a/core/target-systems/flamingock-couchbase-targetsystem/build.gradle.kts
+++ b/core/target-systems/flamingock-couchbase-targetsystem/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
     implementation(project(":legacy:mongock-importer-couchbase"))
 
     //General
-    compileOnly("com.couchbase.client:java-client:3.6.0")
+    compileOnlyApi("com.couchbase.client:java-client:3.6.0")
 
     //Test
     testImplementation("org.testcontainers:testcontainers-couchbase:2.0.2")

--- a/core/target-systems/flamingock-dynamodb-externalsystem-api/build.gradle.kts
+++ b/core/target-systems/flamingock-dynamodb-externalsystem-api/build.gradle.kts
@@ -1,9 +1,9 @@
 val coreApiVersion: String by extra
 dependencies {
-    implementation("io.flamingock:flamingock-core-api:${coreApiVersion}")
+    api("io.flamingock:flamingock-core-api:${coreApiVersion}")
 
     //General
-    compileOnly("software.amazon.awssdk:dynamodb-enhanced:2.25.29")
+    compileOnlyApi("software.amazon.awssdk:dynamodb:2.25.29")
 }
 
 description = "DynamoDB external system api"

--- a/core/target-systems/flamingock-dynamodb-targetsystem/build.gradle.kts
+++ b/core/target-systems/flamingock-dynamodb-targetsystem/build.gradle.kts
@@ -5,7 +5,7 @@ dependencies {
     implementation(project(":utils:dynamodb-util"))
     implementation(project(":legacy:mongock-importer-dynamodb"))
 
-    compileOnly("software.amazon.awssdk:dynamodb-enhanced:2.25.29")
+    compileOnlyApi("software.amazon.awssdk:dynamodb-enhanced:2.25.29")
 
     testImplementation("software.amazon.awssdk:dynamodb:2.25.29")
     testImplementation("software.amazon.awssdk:dynamodb-enhanced:2.25.29")

--- a/core/target-systems/flamingock-mongodb-externalsystem-api/build.gradle.kts
+++ b/core/target-systems/flamingock-mongodb-externalsystem-api/build.gradle.kts
@@ -1,10 +1,8 @@
-val coreApiVersion: String by extra
 dependencies {
-
     api(project(":core:flamingock-core-commons"))
 
     // MongoDB driver for storage implementations
-    compileOnly("org.mongodb:mongodb-driver-sync:4.0.0")
+    compileOnlyApi("org.mongodb:mongodb-driver-sync:4.0.0")
 }
 
 description = "MongoDB external system api"

--- a/core/target-systems/flamingock-mongodb-reactive-externalsystem-api/build.gradle.kts
+++ b/core/target-systems/flamingock-mongodb-reactive-externalsystem-api/build.gradle.kts
@@ -1,9 +1,9 @@
 val coreApiVersion: String by extra
 
 dependencies {
-    implementation("io.flamingock:flamingock-core-api:${coreApiVersion}")
+    api("io.flamingock:flamingock-core-api:${coreApiVersion}")
 
-    compileOnly("org.mongodb:mongodb-driver-reactivestreams:4.0.0")
+    compileOnlyApi("org.mongodb:mongodb-driver-reactivestreams:4.0.0")
 }
 
 description = "MongoDB reactive external system api"

--- a/core/target-systems/flamingock-mongodb-reactive-targetsystem/build.gradle.kts
+++ b/core/target-systems/flamingock-mongodb-reactive-targetsystem/build.gradle.kts
@@ -3,10 +3,10 @@ dependencies {
     implementation(project(":utils:mongodb-util"))
     implementation(project(":utils:mongodb-reactive-util"))
     implementation(project(":legacy:mongock-importer-mongodb-reactive"))
-    api(project(":utils:flamingock-reactive-util"))
+    implementation(project(":utils:flamingock-reactive-util"))
     api(project(":core:target-systems:flamingock-mongodb-reactive-externalsystem-api"))
 
-    compileOnly("org.mongodb:mongodb-driver-reactivestreams:4.0.0")
+    compileOnlyApi("org.mongodb:mongodb-driver-reactivestreams:4.0.0")
 
     testImplementation("org.testcontainers:testcontainers-mongodb:2.0.2")
     testImplementation("org.testcontainers:testcontainers-junit-jupiter:2.0.2")

--- a/core/target-systems/flamingock-mongodb-springdata-reactive-targetsystem/build.gradle.kts
+++ b/core/target-systems/flamingock-mongodb-springdata-reactive-targetsystem/build.gradle.kts
@@ -7,12 +7,12 @@ val versions = mapOf(
 
 dependencies {
     api(project(":core:flamingock-core"))
-    api(project(":utils:flamingock-reactive-util"))
+    implementation(project(":utils:flamingock-reactive-util"))
     api(project(":core:target-systems:flamingock-mongodb-reactive-externalsystem-api"))
     implementation(project(":legacy:mongock-importer-mongodb-reactive"))
 
-    compileOnly("org.mongodb:mongodb-driver-reactivestreams:${versions["mongodb"]}")
-    compileOnly("org.springframework.data:spring-data-mongodb:${versions["spring-data"]}")
+    compileOnlyApi("org.mongodb:mongodb-driver-reactivestreams:${versions["mongodb"]}")
+    compileOnlyApi("org.springframework.data:spring-data-mongodb:${versions["spring-data"]}")
     compileOnly("io.projectreactor:reactor-core:3.4.34")
 
     testImplementation("org.testcontainers:testcontainers-mongodb:2.0.2")

--- a/core/target-systems/flamingock-mongodb-springdata-targetsystem/build.gradle.kts
+++ b/core/target-systems/flamingock-mongodb-springdata-targetsystem/build.gradle.kts
@@ -15,8 +15,8 @@ dependencies {
     api(project(":core:target-systems:flamingock-mongodb-externalsystem-api"))
 
     //General
-    compileOnly("org.mongodb:mongodb-driver-sync:${versions["mongodb"]}")
-    compileOnly("org.springframework.data:spring-data-mongodb:${versions["spring-data"]}")
+    compileOnlyApi("org.mongodb:mongodb-driver-sync:${versions["mongodb"]}")
+    compileOnlyApi("org.springframework.data:spring-data-mongodb:${versions["spring-data"]}")
 
     //Test
     testImplementation("org.testcontainers:testcontainers-mongodb:2.0.2")

--- a/core/target-systems/flamingock-mongodb-sync-targetsystem/build.gradle.kts
+++ b/core/target-systems/flamingock-mongodb-sync-targetsystem/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
     api(project(":core:target-systems:flamingock-mongodb-externalsystem-api"))
 
     //General
-    compileOnly("org.mongodb:mongodb-driver-sync:4.0.0")
+    compileOnlyApi("org.mongodb:mongodb-driver-sync:4.0.0")
 
     //Test
     testImplementation("org.testcontainers:testcontainers-mongodb:2.0.2")

--- a/core/target-systems/flamingock-sql-externalsystem-api/build.gradle.kts
+++ b/core/target-systems/flamingock-sql-externalsystem-api/build.gradle.kts
@@ -1,11 +1,9 @@
 val coreApiVersion: String by extra
 val sqlVersion: String by extra
 dependencies {
-    implementation("io.flamingock:flamingock-core-api:${coreApiVersion}")
+    api("io.flamingock:flamingock-core-api:${coreApiVersion}")
     implementation("io.flamingock:flamingock-sql-util:${sqlVersion}")
 
-    //General
-    compileOnly("software.amazon.awssdk:dynamodb-enhanced:2.25.29")
 }
 
 description = "DynamoDB external system api"

--- a/core/target-systems/flamingock-sql-targetsystem/build.gradle.kts
+++ b/core/target-systems/flamingock-sql-targetsystem/build.gradle.kts
@@ -6,7 +6,7 @@ val sqlVersion: String by extra
 dependencies {
     //Flamingock
     api(project(":core:flamingock-core"))
-    implementation(project(":core:target-systems:flamingock-sql-externalsystem-api"))
+    api(project(":core:target-systems:flamingock-sql-externalsystem-api"))
     implementation("io.flamingock:flamingock-sql-util:${sqlVersion}")
 
     //Test

--- a/e2e/core-e2e/build.gradle.kts
+++ b/e2e/core-e2e/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.9.2")
     testImplementation("org.mockito:mockito-core:4.11.0")
     testImplementation("org.mockito:mockito-junit-jupiter:4.11.0")
+    testImplementation("javax.inject:javax.inject:1")
 }
 
 description = "End-to-end integration tests for core functionality"

--- a/legacy/mongock-importer-couchbase/build.gradle.kts
+++ b/legacy/mongock-importer-couchbase/build.gradle.kts
@@ -1,9 +1,9 @@
 dependencies {
-    implementation(project(":core:flamingock-core-commons"))
+    api(project(":core:flamingock-core-commons"))
     implementation(project(":utils:couchbase-util"))
 
     //General
-    compileOnly("com.couchbase.client:java-client:3.6.0")
+    compileOnlyApi("com.couchbase.client:java-client:3.6.0")
 
 
     testAnnotationProcessor(project(":core:flamingock-processor"))

--- a/legacy/mongock-importer-dynamodb/build.gradle.kts
+++ b/legacy/mongock-importer-dynamodb/build.gradle.kts
@@ -1,8 +1,8 @@
 dependencies {
-    implementation(project(":core:flamingock-core-commons"))
+    api(project(":core:flamingock-core-commons"))
     implementation(project(":utils:dynamodb-util"))
 
-    compileOnly("software.amazon.awssdk:dynamodb-enhanced:2.25.29")
+    compileOnlyApi("software.amazon.awssdk:dynamodb-enhanced:2.25.29")
 
     testAnnotationProcessor(project(":core:flamingock-processor"))
     testAnnotationProcessor(project(":legacy:mongock-support"))

--- a/legacy/mongock-importer-mongodb-reactive/build.gradle.kts
+++ b/legacy/mongock-importer-mongodb-reactive/build.gradle.kts
@@ -1,7 +1,7 @@
 dependencies {
     implementation(project(":core:flamingock-core-commons"))
     implementation(project(":utils:flamingock-reactive-util"))
-    compileOnly("org.mongodb:mongodb-driver-reactivestreams:4.0.0")
+    compileOnlyApi("org.mongodb:mongodb-driver-reactivestreams:4.0.0")
 
     testAnnotationProcessor(project(":core:flamingock-processor"))
     testAnnotationProcessor(project(":legacy:mongock-support"))

--- a/legacy/mongock-importer-mongodb/build.gradle.kts
+++ b/legacy/mongock-importer-mongodb/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
-    implementation(project(":core:flamingock-core-commons"))
-    compileOnly("org.mongodb:mongodb-driver-sync:4.0.0")
+    api(project(":core:flamingock-core-commons"))
+    compileOnlyApi("org.mongodb:mongodb-driver-sync:4.0.0")
 
     testAnnotationProcessor(project(":core:flamingock-processor"))
     testAnnotationProcessor(project(":legacy:mongock-support"))

--- a/legacy/mongock-support/build.gradle.kts
+++ b/legacy/mongock-support/build.gradle.kts
@@ -1,7 +1,6 @@
-val coreApiVersion: String by extra
 dependencies {
-    api(project(":core:flamingock-core"))//todo implementation
-    api("io.flamingock:flamingock-core-api:${coreApiVersion}")//todo remove. This should be imported by core
+    api(project(":core:flamingock-core"))
+    compileOnlyApi("javax.inject:javax.inject:1")
 }
 
 description = "Provides a compatibility layer for Mongock-based applications, including drop-in annotations and audit store migration utilities to Flamingock."

--- a/platform-plugins/flamingock-springboot-integration/build.gradle.kts
+++ b/platform-plugins/flamingock-springboot-integration/build.gradle.kts
@@ -3,9 +3,9 @@ val springBootVersion = "2.0.0.RELEASE"
 val springFrameworkVersion = "5.0.4.RELEASE"
 dependencies {
     api(project(":core:flamingock-core"))
-    compileOnly("org.springframework:spring-context:${springFrameworkVersion}")
-    compileOnly("org.springframework.boot:spring-boot:${springBootVersion}")
-    compileOnly("org.springframework.boot:spring-boot-autoconfigure:${springBootVersion}")
+    compileOnlyApi("org.springframework:spring-context:${springFrameworkVersion}")
+    compileOnlyApi("org.springframework.boot:spring-boot:${springBootVersion}")
+    compileOnlyApi("org.springframework.boot:spring-boot-autoconfigure:${springBootVersion}")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor:${springBootVersion}")
 
 

--- a/platform-plugins/flamingock-springboot-test-support/build.gradle.kts
+++ b/platform-plugins/flamingock-springboot-test-support/build.gradle.kts
@@ -4,13 +4,13 @@ dependencies {
     api(project(":core:flamingock-test-support"))
 
     implementation(project(":core:flamingock-core"))
-    compileOnly("org.springframework:spring-context:${springFrameworkVersion}")
-    compileOnly("org.springframework.boot:spring-boot:${springBootVersion}")
-    compileOnly("org.springframework.boot:spring-boot-autoconfigure:${springBootVersion}")
+    compileOnlyApi("org.springframework:spring-context:${springFrameworkVersion}")
+    compileOnlyApi("org.springframework.boot:spring-boot:${springBootVersion}")
+    compileOnlyApi("org.springframework.boot:spring-boot-autoconfigure:${springBootVersion}")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor:${springBootVersion}")
 
     // Required for @FlamingockSpringBootTest annotation
-    implementation("org.springframework.boot:spring-boot-test:${springBootVersion}")
+    api("org.springframework.boot:spring-boot-test:${springBootVersion}")
     implementation("org.springframework:spring-test:${springFrameworkVersion}")
 
 

--- a/utils/couchbase-test-kit/build.gradle.kts
+++ b/utils/couchbase-test-kit/build.gradle.kts
@@ -1,9 +1,9 @@
 dependencies {
     implementation(project(":core:flamingock-core"))
     implementation(project(":utils:couchbase-util"))
-    implementation(project(":utils:test-util"))
+    api(project(":utils:test-util"))
 
-    compileOnly("com.couchbase.client:java-client:3.6.0")
+    compileOnlyApi("com.couchbase.client:java-client:3.6.0")
 }
 
 description = "Couchbase TestKit for Flamingock testing"

--- a/utils/couchbase-util/build.gradle.kts
+++ b/utils/couchbase-util/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
     implementation(project(":core:flamingock-core"))
-    compileOnly("com.couchbase.client:java-client:3.6.0")
+    compileOnlyApi("com.couchbase.client:java-client:3.6.0")
     
     testImplementation(project(":utils:test-util"))
     testImplementation("com.couchbase.client:java-client:3.6.0")

--- a/utils/dynamodb-test-kit/build.gradle.kts
+++ b/utils/dynamodb-test-kit/build.gradle.kts
@@ -1,15 +1,13 @@
-val generalUtilVersion: String by extra
 dependencies {
     implementation(project(":core:flamingock-core"))
     implementation(project(":utils:dynamodb-util"))
-    implementation("io.flamingock:flamingock-general-util:${generalUtilVersion}")
-    implementation(project(":utils:test-util"))
+    api(project(":utils:test-util"))
 
-    compileOnly("software.amazon.awssdk:dynamodb-enhanced:2.25.29")
+    compileOnlyApi("software.amazon.awssdk:dynamodb-enhanced:2.25.29")
 
-    compileOnly("software.amazon.awssdk:url-connection-client:2.24.11")
+    implementation("software.amazon.awssdk:url-connection-client:2.24.11")
 
-    compileOnly("org.testcontainers:testcontainers:2.0.2")
+    compileOnlyApi("org.testcontainers:testcontainers:2.0.2")
     compileOnly("org.testcontainers:testcontainers-junit-jupiter:2.0.2")
 }
 

--- a/utils/dynamodb-util/build.gradle.kts
+++ b/utils/dynamodb-util/build.gradle.kts
@@ -1,9 +1,7 @@
-val generalUtilVersion: String by extra
 dependencies {
     implementation(project(":core:flamingock-core"))
-    implementation("io.flamingock:flamingock-general-util:${generalUtilVersion}")
 
-    compileOnly("software.amazon.awssdk:dynamodb-enhanced:2.25.29")
+    compileOnlyApi("software.amazon.awssdk:dynamodb-enhanced:2.25.29")
 }
 
 description = "Amazon DynamoDB utilities and helpers for database operations"

--- a/utils/mongodb-reactive-test-kit/build.gradle.kts
+++ b/utils/mongodb-reactive-test-kit/build.gradle.kts
@@ -2,9 +2,9 @@ dependencies {
     implementation(project(":core:flamingock-core"))
     implementation(project(":utils:mongodb-util"))
     implementation(project(":utils:flamingock-reactive-util"))
-    implementation(project(":utils:test-util"))
+    api(project(":utils:test-util"))
 
-    compileOnly("org.mongodb:mongodb-driver-reactivestreams:4.0.0")
+    compileOnlyApi("org.mongodb:mongodb-driver-reactivestreams:4.0.0")
 }
 
 description = "MongoDB reactive streams TestKit for Flamingock testing"

--- a/utils/mongodb-reactive-util/build.gradle.kts
+++ b/utils/mongodb-reactive-util/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     implementation(project(":utils:mongodb-util"))
     implementation(project(":core:flamingock-core-commons"))
 
-    compileOnly("org.mongodb:mongodb-driver-reactivestreams:4.0.0")
+    compileOnlyApi("org.mongodb:mongodb-driver-reactivestreams:4.0.0")
 }
 
 description = "MongoDB reactive streams driver utilities"

--- a/utils/mongodb-sync-util/build.gradle.kts
+++ b/utils/mongodb-sync-util/build.gradle.kts
@@ -1,7 +1,7 @@
 dependencies {
     implementation(project(":utils:mongodb-util"))
 
-    compileOnly("org.mongodb:mongodb-driver-sync:4.0.0")
+    compileOnlyApi("org.mongodb:mongodb-driver-sync:4.0.0")
 }
 
 description = "MongoDB synchronous driver utilities"

--- a/utils/mongodb-test-kit/build.gradle.kts
+++ b/utils/mongodb-test-kit/build.gradle.kts
@@ -1,9 +1,9 @@
 dependencies {
     implementation(project(":core:flamingock-core"))
     implementation(project(":utils:mongodb-util"))
-    implementation(project(":utils:test-util"))
+    api(project(":utils:test-util"))
 
-    compileOnly("org.mongodb:mongodb-driver-sync:4.0.0")
+    compileOnlyApi("org.mongodb:mongodb-driver-sync:4.0.0")
 }
 
 description = "MongoDB TestKit for Flamingock testing"

--- a/utils/mongodb-util/build.gradle.kts
+++ b/utils/mongodb-util/build.gradle.kts
@@ -1,7 +1,7 @@
 dependencies {
     implementation(project(":core:flamingock-core"))
 
-    compileOnly("org.mongodb:bson:4.0.0")
+    compileOnlyApi("org.mongodb:bson:4.0.0")
 
     testImplementation(project(":utils:test-util"))
 }

--- a/utils/reactive-util/build.gradle.kts
+++ b/utils/reactive-util/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    compileOnly("org.reactivestreams:reactive-streams:1.0.3")
+    compileOnlyApi("org.reactivestreams:reactive-streams:1.0.3")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")

--- a/utils/sql-test-kit/build.gradle.kts
+++ b/utils/sql-test-kit/build.gradle.kts
@@ -2,7 +2,7 @@ val sqlVersion: String by extra
 dependencies {
     implementation(project(":core:flamingock-core"))
     implementation("io.flamingock:flamingock-sql-util:${sqlVersion}")
-    implementation(project(":utils:test-util"))
+    api(project(":utils:test-util"))
 }
 
 description = "SQL TestKit for Flamingock testing"

--- a/utils/test-util/build.gradle.kts
+++ b/utils/test-util/build.gradle.kts
@@ -1,27 +1,15 @@
-val jacksonVersion = "2.16.0"
-val generalUtilVersion: String by extra
 dependencies {
 
-    api("io.flamingock:flamingock-general-util:${generalUtilVersion}")
     api(project(":cloud:flamingock-cloud-api"))
     api(project(":core:flamingock-core"))
-    api(project(":core:flamingock-core-commons"))
-    api(project(":core:flamingock-processor"))
+    implementation(project(":core:flamingock-processor"))
 
-    api("javax.inject:javax.inject:1")
-    api("org.objenesis:objenesis:3.2")
-    api("org.yaml:snakeyaml:2.2")
-
-    api("org.apache.httpcomponents:httpclient:4.5.14")
-    
-    api("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
-    
-
-    api("com.github.tomakehurst:wiremock-jre8:2.35.2")
+    implementation("com.github.tomakehurst:wiremock-jre8:2.35.2")
+    api("com.fasterxml.jackson.core:jackson-databind:2.16.0")
     
     // JUnit for assertion utilities
-    api("org.junit.jupiter:junit-jupiter-api:5.9.2")
-    api("org.mockito:mockito-inline:4.11.0")
+    implementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
+    implementation("org.mockito:mockito-inline:4.11.0")
 
 }
 


### PR DESCRIPTION
## Summary

- Align dependency scopes with actual public API and runtime usage.
- Keep third-party drivers and framework integrations application-provided.
- Preserve Flamingock artifacts as the only intended transitive Flamingock dependencies.

## Changes

- Reclassified vendor dependencies exposed in public APIs as `compileOnlyApi`.
- Removed redundant direct dependencies that are already provided through the intended Flamingock module graph.
- Marked external `compileOnlyApi` dependencies as optional in generated Maven POMs.
- Removed the obsolete MongoDB Spring Data audit-store BOM constraint.
- Removed the redundant direct Reactive Streams declaration from the MongoDB reactive utility.

## Why

Applications should choose and provide only the infrastructure drivers they use. Flamingock must not transitively pull MongoDB, Couchbase, DynamoDB, Spring, GraalVM, or similar integrations into consumer runtime classpaths.

Gradle metadata already distinguishes compile-only API dependencies from runtime dependencies. The publication adjustment brings Maven behavior in line by marking third-party integration dependencies as optional.

## Benefits

- Smaller application runtime classpaths.
- Fewer driver and framework version conflicts.
- Clear ownership of external infrastructure dependencies.
- Accurate published metadata for APIs that expose optional provider types.

## Validation

- Generated representative Maven POMs and verified external integration dependencies are optional.
- Verified Flamingock and implementation dependencies retain their intended transitivity.
- Compiled affected modules successfully with Java 17.0.8 GraalVM.
- Completed independent dependency-scope and publication-metadata reviews.